### PR TITLE
raise dependabot threashold

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,10 +4,10 @@ updates:
   directory: "/"
   schedule:
     interval: daily
-  open-pull-requests-limit: 10
+  open-pull-requests-limit: 50
 
 - package-ecosystem: gitsubmodule
   directory: "/"
   schedule:
     interval: daily
-  open-pull-requests-limit: 10
+  open-pull-requests-limit: 50

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,10 +4,10 @@ updates:
   directory: "/"
   schedule:
     interval: daily
-  open-pull-requests-limit: 5
+  open-pull-requests-limit: 10
 
 - package-ecosystem: gitsubmodule
   directory: "/"
   schedule:
     interval: daily
-  open-pull-requests-limit: 2
+  open-pull-requests-limit: 10


### PR DESCRIPTION
Soundtrack of this PR: [Raise the roof](https://www.youtube.com/watch?v=sT_78skgs9k) 

### Motivation

Yall limiting the dependabots bottyness too much. 

### In this PR
* Raises the dependabot pull request limits, yall are open source so circleci should be giving you a ton of credits to run for free on dependant systems. 
 

### Future Work
Yall should consider:
* Bors merge train
* Snyk, which you would pay for but is a bit better than dependabot.
* Resizing your circle nodes as yall are using xls 
* Requiring gifs in pull requests 
* Allowing issues to be created on this repo.

