### PR TITLE
Fix typo in libmobilecoin

### DIFF
--- a/libmobilecoin/include/bip39.h
+++ b/libmobilecoin/include/bip39.h
@@ -54,7 +54,7 @@ MC_ATTRIBUTE_NONNULL(1, 2, 3);
 /// # Preconditions
 ///
 /// * `prefix` - must be a nul-terminated C string containing valid UTF-8.
-char* MC_NULLABLE mc_bip32_words_by_prefix(
+char* MC_NULLABLE mc_bip39_words_by_prefix(
   const char* MC_NONNULL prefix
 )
 MC_ATTRIBUTE_NONNULL(1);

--- a/libmobilecoin/libmobilecoin_cbindgen.h
+++ b/libmobilecoin/libmobilecoin_cbindgen.h
@@ -384,7 +384,7 @@ bool mc_bip39_get_seed(FfiStr mnemonic,
  *
  * * `prefix` - must be a nul-terminated C string containing valid UTF-8.
  */
-FfiOptOwnedStr mc_bip32_words_by_prefix(FfiStr prefix);
+FfiOptOwnedStr mc_bip39_words_by_prefix(FfiStr prefix);
 
 bool mc_ristretto_private_validate(FfiRefPtr<McBuffer> ristretto_private,
                                    FfiMutPtr<bool> out_valid);

--- a/libmobilecoin/src/bip39.rs
+++ b/libmobilecoin/src/bip39.rs
@@ -88,7 +88,7 @@ pub extern "C" fn mc_bip39_get_seed(
 ///
 /// * `prefix` - must be a nul-terminated C string containing valid UTF-8.
 #[no_mangle]
-pub extern "C" fn mc_bip32_words_by_prefix(prefix: FfiStr) -> FfiOptOwnedStr {
+pub extern "C" fn mc_bip39_words_by_prefix(prefix: FfiStr) -> FfiOptOwnedStr {
     ffi_boundary(|| {
         let prefix = String::try_from_ffi(prefix).expect("prefix is invalid");
         let words = Language::English.words_by_prefix(&prefix);


### PR DESCRIPTION
This fixes a simple typo in a libmobilecoin function name, changing `mc_bip32_words_by_prefix` to `mc_bip39_words_by_prefix`.