### PR TITLE
Return entropy size from mc_bip39_entropy_from_mnemonic

### DIFF
--- a/libmobilecoin/include/bip39.h
+++ b/libmobilecoin/include/bip39.h
@@ -14,21 +14,21 @@ extern "C" {
 /// # Preconditions
 ///
 /// * `mnemonic` - must be a nul-terminated C string containing valid UTF-8.
-/// * `out_entropy` - length must be >= 32.
+/// * `out_entropy` - must be null or else length must be >= `entropy.len`.
 ///
 /// # Errors
 ///
 /// * `LibMcError::InvalidInput`
-bool mc_bip39_entropy_from_mnemonic(
+ssize_t mc_bip39_entropy_from_mnemonic(
   const char* MC_NONNULL mnemonic,
-  McMutableBuffer* MC_NONNULL out_entropy,
+  McMutableBuffer* MC_NULLABLE out_entropy,
   McError* MC_NULLABLE * MC_NULLABLE out_error
 )
-MC_ATTRIBUTE_NONNULL(1, 2);
+MC_ATTRIBUTE_NONNULL(1);
 
 /// # Preconditions
 ///
-/// * `entropy` - length must be 32.
+/// * `entropy` - length must be a multiple of 4 and between 16 and 32, inclusive.
 char* MC_NULLABLE mc_bip39_entropy_to_mnemonic(
   const McBuffer* MC_NONNULL entropy
 )

--- a/libmobilecoin/libmobilecoin_cbindgen.h
+++ b/libmobilecoin/libmobilecoin_cbindgen.h
@@ -346,20 +346,20 @@ ssize_t mc_attest_ake_decrypt(FfiMutPtr<McAttestAke> attest_ake,
  * # Preconditions
  *
  * * `mnemonic` - must be a nul-terminated C string containing valid UTF-8.
- * * `out_entropy` - length must be >= 32.
+ * * `out_entropy` - must be null or else length must be >= `entropy.len`.
  *
  * # Errors
  *
  * * `LibMcError::InvalidInput`
  */
-bool mc_bip39_entropy_from_mnemonic(FfiStr mnemonic,
-                                    FfiMutPtr<McMutableBuffer> out_entropy,
-                                    FfiOptMutPtr<FfiOptOwnedPtr<McError>> out_error);
+ssize_t mc_bip39_entropy_from_mnemonic(FfiStr mnemonic,
+                                       FfiOptMutPtr<McMutableBuffer> out_entropy,
+                                       FfiOptMutPtr<FfiOptOwnedPtr<McError>> out_error);
 
 /**
  * # Preconditions
  *
- * * `entropy` - length must be 32.
+ * * `entropy` - length must be a multiple of 4 and between 16 and 32, inclusive.
  */
 FfiOptOwnedStr mc_bip39_entropy_to_mnemonic(FfiRefPtr<McBuffer> entropy);
 


### PR DESCRIPTION
The entropy used in BIP-39 is variable in size, but this is not reflected in the libmobilecoin function `mc_bip39_entropy_from_mnemonic`, which states only that the size of `out_entropy` must be greater than 32. However, without also returning the size, it would be unknown how many of those bytes were left unset. This PR fixes this by returning the entropy size from `mc_bip39_entropy_from_mnemonic`. It also fixes up the comments for both `mc_bip39_entropy_from_mnemonic` and `mc_bip39_entropy_to_mnemonic`.