### PR TITLE
fog conformance tests: add a happy path 2nd server + retire test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -863,16 +863,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "displaydoc"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "proc-macro2 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "displaydoc"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -1054,7 +1044,7 @@ name = "fog-enclave-connection"
 version = "0.13.0"
 dependencies = [
  "aes-gcm 0.6.0 (git+https://github.com/mobilecoinofficial/AEADs?rev=d1a8517d3dd867ed9c5794002add67992a42f6aa)",
- "displaydoc 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "displaydoc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpcio 0.6.0 (git+https://github.com/jcape/grpc-rs?rev=2ad042e9e65ecb664a60e034d0a899a8760d81d3)",
  "mc-attest-ake 1.0.1-pre1",
  "mc-attest-api 1.0.1-pre1",
@@ -1074,7 +1064,7 @@ dependencies = [
 name = "fog-ingest-client"
 version = "0.13.0"
 dependencies = [
- "displaydoc 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "displaydoc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fog-api 0.13.0",
  "fog-types 0.13.0",
  "fog-uri 0.13.0",
@@ -1130,7 +1120,7 @@ dependencies = [
 name = "fog-ingest-enclave-api"
 version = "0.13.0"
 dependencies = [
- "displaydoc 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "displaydoc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fog-kex-rng 0.13.0",
  "fog-types 0.13.0",
  "mc-attest-core 1.0.1-pre1",
@@ -1201,7 +1191,7 @@ name = "fog-ingest-server"
 version = "0.13.0"
 dependencies = [
  "dirs 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "displaydoc 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "displaydoc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fog-api 0.13.0",
  "fog-ingest-client 0.13.0",
  "fog-ingest-enclave 0.13.0",
@@ -1254,7 +1244,7 @@ name = "fog-kex-rng"
 version = "0.13.0"
 dependencies = [
  "blake2 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "displaydoc 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "displaydoc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "mc-crypto-keys 1.0.1-pre1",
  "mc-util-from-random 1.0.1-pre1",
  "mc-util-repr-bytes 1.0.1-pre1",
@@ -1268,7 +1258,7 @@ dependencies = [
 name = "fog-ledger-connection"
 version = "0.13.0"
 dependencies = [
- "displaydoc 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "displaydoc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fog-api 0.13.0",
  "fog-enclave-connection 0.13.0",
  "fog-types 0.13.0",
@@ -1312,7 +1302,7 @@ dependencies = [
 name = "fog-ledger-enclave-api"
 version = "0.13.0"
 dependencies = [
- "displaydoc 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "displaydoc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fog-types 0.13.0",
  "mc-attest-core 1.0.1-pre1",
  "mc-attest-enclave-api 1.0.1-pre1",
@@ -1366,7 +1356,7 @@ name = "fog-ledger-server"
 version = "0.13.0"
 dependencies = [
  "curve25519-dalek 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "displaydoc 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "displaydoc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fog-api 0.13.0",
  "fog-ledger-connection 0.13.0",
  "fog-ledger-enclave 0.13.0",
@@ -1480,7 +1470,7 @@ dependencies = [
  "aligned-cmov 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "balanced-tree-index 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "blake2 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "displaydoc 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "displaydoc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "mc-oblivious-traits 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "mc-sgx-compat 1.0.1-pre1",
@@ -1500,7 +1490,7 @@ dependencies = [
 name = "fog-recovery-db-iface"
 version = "0.13.0"
 dependencies = [
- "displaydoc 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "displaydoc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fog-kex-rng 0.13.0",
  "fog-types 0.13.0",
  "mc-attest-core 1.0.1-pre1",
@@ -1532,7 +1522,7 @@ dependencies = [
 name = "fog-report-server"
 version = "0.13.0"
 dependencies = [
- "displaydoc 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "displaydoc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fog-api 0.13.0",
  "fog-recovery-db-iface 0.13.0",
  "fog-sql-recovery-db 0.13.0",
@@ -1566,7 +1556,7 @@ dependencies = [
 name = "fog-sample-paykit"
 version = "0.13.0"
 dependencies = [
- "displaydoc 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "displaydoc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fog-api 0.13.0",
  "fog-enclave-connection 0.13.0",
  "fog-ingest-enclave-measurement 0.13.0",
@@ -1607,7 +1597,7 @@ dependencies = [
  "diesel 1.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "diesel-derive-enum 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "diesel_migrations 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "displaydoc 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "displaydoc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fog-kex-rng 0.13.0",
  "fog-recovery-db-iface 0.13.0",
  "fog-test-infra 0.13.0",
@@ -1679,7 +1669,7 @@ name = "fog-types"
 version = "0.13.0"
 dependencies = [
  "blake2 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "displaydoc 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "displaydoc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fog-kex-rng 0.13.0",
  "mc-crypto-keys 1.0.1-pre1",
  "mc-transaction-core 1.0.1-pre1",
@@ -1755,7 +1745,7 @@ dependencies = [
 name = "fog-view-enclave-api"
 version = "0.13.0"
 dependencies = [
- "displaydoc 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "displaydoc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fog-recovery-db-iface 0.13.0",
  "fog-types 0.13.0",
  "mc-attest-core 1.0.1-pre1",
@@ -1833,7 +1823,7 @@ name = "fog-view-protocol"
 version = "0.13.0"
 dependencies = [
  "blake2 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "displaydoc 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "displaydoc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fog-kex-rng 0.13.0",
  "fog-types 0.13.0",
  "mc-account-keys 1.0.1-pre1",
@@ -1855,7 +1845,7 @@ dependencies = [
 name = "fog-view-server"
 version = "0.13.0"
 dependencies = [
- "displaydoc 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "displaydoc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fog-api 0.13.0",
  "fog-kex-rng 0.13.0",
  "fog-recovery-db-iface 0.13.0",
@@ -2431,7 +2421,7 @@ dependencies = [
  "bip39 1.0.0-rc1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cbindgen 0.14.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "cmake 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "displaydoc 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "displaydoc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fog-kex-rng 0.13.0",
  "libc 0.2.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "mc-account-keys 1.0.1-pre1",
@@ -2583,7 +2573,7 @@ version = "0.13.0"
 dependencies = [
  "aes-gcm 0.6.0 (git+https://github.com/mobilecoinofficial/AEADs?rev=d1a8517d3dd867ed9c5794002add67992a42f6aa)",
  "bip39 1.0.0-rc1 (registry+https://github.com/rust-lang/crates.io-index)",
- "displaydoc 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "displaydoc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fog-kex-rng 0.13.0",
  "jni 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "mc-account-keys 1.0.1-pre1",
@@ -5865,7 +5855,6 @@ dependencies = [
 "checksum dirs 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "13aea89a5c93364a98e9b37b2fa237effbb694d5cfe01c5b70941f7eb087d5e3"
 "checksum dirs-sys 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "afa0b23de8fd801745c471deffa6e12d248f962c9fd4b4c33787b055599bde7b"
 "checksum discard 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
-"checksum displaydoc 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "adc2ab4d5a16117f9029e9a6b5e4e79f4c67f6519bc134210d4d4a04ba31f41b"
 "checksum displaydoc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f98e1bbbcbb1b2646d6e900da42974b641eb784851adcd4f0ae4c07c8bc7b42b"
 "checksum downcast 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4bb454f0228b18c7f4c3b0ebbee346ed9c52e7443b0999cd543ff3571205701d"
 "checksum dtoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "4358a9e11b9a09cf52383b451b49a169e8d797b68aa02301ff586d70d9661ea3"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -863,6 +863,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "displaydoc"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "displaydoc"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -1044,7 +1054,7 @@ name = "fog-enclave-connection"
 version = "0.13.0"
 dependencies = [
  "aes-gcm 0.6.0 (git+https://github.com/mobilecoinofficial/AEADs?rev=d1a8517d3dd867ed9c5794002add67992a42f6aa)",
- "displaydoc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "displaydoc 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpcio 0.6.0 (git+https://github.com/jcape/grpc-rs?rev=2ad042e9e65ecb664a60e034d0a899a8760d81d3)",
  "mc-attest-ake 1.0.1-pre1",
  "mc-attest-api 1.0.1-pre1",
@@ -1064,7 +1074,7 @@ dependencies = [
 name = "fog-ingest-client"
 version = "0.13.0"
 dependencies = [
- "displaydoc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "displaydoc 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "fog-api 0.13.0",
  "fog-types 0.13.0",
  "fog-uri 0.13.0",
@@ -1120,7 +1130,7 @@ dependencies = [
 name = "fog-ingest-enclave-api"
 version = "0.13.0"
 dependencies = [
- "displaydoc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "displaydoc 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "fog-kex-rng 0.13.0",
  "fog-types 0.13.0",
  "mc-attest-core 1.0.1-pre1",
@@ -1191,7 +1201,7 @@ name = "fog-ingest-server"
 version = "0.13.0"
 dependencies = [
  "dirs 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "displaydoc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "displaydoc 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "fog-api 0.13.0",
  "fog-ingest-client 0.13.0",
  "fog-ingest-enclave 0.13.0",
@@ -1244,7 +1254,7 @@ name = "fog-kex-rng"
 version = "0.13.0"
 dependencies = [
  "blake2 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "displaydoc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "displaydoc 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "mc-crypto-keys 1.0.1-pre1",
  "mc-util-from-random 1.0.1-pre1",
  "mc-util-repr-bytes 1.0.1-pre1",
@@ -1258,7 +1268,7 @@ dependencies = [
 name = "fog-ledger-connection"
 version = "0.13.0"
 dependencies = [
- "displaydoc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "displaydoc 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "fog-api 0.13.0",
  "fog-enclave-connection 0.13.0",
  "fog-types 0.13.0",
@@ -1302,7 +1312,7 @@ dependencies = [
 name = "fog-ledger-enclave-api"
 version = "0.13.0"
 dependencies = [
- "displaydoc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "displaydoc 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "fog-types 0.13.0",
  "mc-attest-core 1.0.1-pre1",
  "mc-attest-enclave-api 1.0.1-pre1",
@@ -1356,7 +1366,7 @@ name = "fog-ledger-server"
 version = "0.13.0"
 dependencies = [
  "curve25519-dalek 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "displaydoc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "displaydoc 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "fog-api 0.13.0",
  "fog-ledger-connection 0.13.0",
  "fog-ledger-enclave 0.13.0",
@@ -1470,7 +1480,7 @@ dependencies = [
  "aligned-cmov 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "balanced-tree-index 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "blake2 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "displaydoc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "displaydoc 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "mc-oblivious-traits 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "mc-sgx-compat 1.0.1-pre1",
@@ -1490,7 +1500,7 @@ dependencies = [
 name = "fog-recovery-db-iface"
 version = "0.13.0"
 dependencies = [
- "displaydoc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "displaydoc 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "fog-kex-rng 0.13.0",
  "fog-types 0.13.0",
  "mc-attest-core 1.0.1-pre1",
@@ -1522,7 +1532,7 @@ dependencies = [
 name = "fog-report-server"
 version = "0.13.0"
 dependencies = [
- "displaydoc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "displaydoc 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "fog-api 0.13.0",
  "fog-recovery-db-iface 0.13.0",
  "fog-sql-recovery-db 0.13.0",
@@ -1556,7 +1566,7 @@ dependencies = [
 name = "fog-sample-paykit"
 version = "0.13.0"
 dependencies = [
- "displaydoc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "displaydoc 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "fog-api 0.13.0",
  "fog-enclave-connection 0.13.0",
  "fog-ingest-enclave-measurement 0.13.0",
@@ -1597,7 +1607,7 @@ dependencies = [
  "diesel 1.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "diesel-derive-enum 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "diesel_migrations 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "displaydoc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "displaydoc 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "fog-kex-rng 0.13.0",
  "fog-recovery-db-iface 0.13.0",
  "fog-test-infra 0.13.0",
@@ -1669,7 +1679,7 @@ name = "fog-types"
 version = "0.13.0"
 dependencies = [
  "blake2 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "displaydoc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "displaydoc 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "fog-kex-rng 0.13.0",
  "mc-crypto-keys 1.0.1-pre1",
  "mc-transaction-core 1.0.1-pre1",
@@ -1745,7 +1755,7 @@ dependencies = [
 name = "fog-view-enclave-api"
 version = "0.13.0"
 dependencies = [
- "displaydoc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "displaydoc 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "fog-recovery-db-iface 0.13.0",
  "fog-types 0.13.0",
  "mc-attest-core 1.0.1-pre1",
@@ -1823,7 +1833,7 @@ name = "fog-view-protocol"
 version = "0.13.0"
 dependencies = [
  "blake2 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "displaydoc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "displaydoc 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "fog-kex-rng 0.13.0",
  "fog-types 0.13.0",
  "mc-account-keys 1.0.1-pre1",
@@ -1845,7 +1855,7 @@ dependencies = [
 name = "fog-view-server"
 version = "0.13.0"
 dependencies = [
- "displaydoc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "displaydoc 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "fog-api 0.13.0",
  "fog-kex-rng 0.13.0",
  "fog-recovery-db-iface 0.13.0",
@@ -2421,7 +2431,7 @@ dependencies = [
  "bip39 1.0.0-rc1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cbindgen 0.14.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "cmake 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "displaydoc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "displaydoc 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "fog-kex-rng 0.13.0",
  "libc 0.2.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "mc-account-keys 1.0.1-pre1",
@@ -2573,7 +2583,7 @@ version = "0.13.0"
 dependencies = [
  "aes-gcm 0.6.0 (git+https://github.com/mobilecoinofficial/AEADs?rev=d1a8517d3dd867ed9c5794002add67992a42f6aa)",
  "bip39 1.0.0-rc1 (registry+https://github.com/rust-lang/crates.io-index)",
- "displaydoc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "displaydoc 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "fog-kex-rng 0.13.0",
  "jni 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "mc-account-keys 1.0.1-pre1",
@@ -5855,6 +5865,7 @@ dependencies = [
 "checksum dirs 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "13aea89a5c93364a98e9b37b2fa237effbb694d5cfe01c5b70941f7eb087d5e3"
 "checksum dirs-sys 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "afa0b23de8fd801745c471deffa6e12d248f962c9fd4b4c33787b055599bde7b"
 "checksum discard 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
+"checksum displaydoc 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "adc2ab4d5a16117f9029e9a6b5e4e79f4c67f6519bc134210d4d4a04ba31f41b"
 "checksum displaydoc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f98e1bbbcbb1b2646d6e900da42974b641eb784851adcd4f0ae4c07c8bc7b42b"
 "checksum downcast 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4bb454f0228b18c7f4c3b0ebbee346ed9c52e7443b0999cd543ff3571205701d"
 "checksum dtoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "4358a9e11b9a09cf52383b451b49a169e8d797b68aa02301ff586d70d9661ea3"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1079,6 +1079,7 @@ dependencies = [
  "mc-util-uri 1.0.1-pre1",
  "protobuf 2.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "retry 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.60 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.3.21 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/fog/ingest/client/Cargo.toml
+++ b/fog/ingest/client/Cargo.toml
@@ -20,6 +20,7 @@ grpcio = "0.6.0"
 hex = "0.4"
 protobuf = "2.12"
 retry = "1.2"
+serde_json = "1.0"
 structopt = "0.3"
 
 # root

--- a/tools/fog-local-network/fog_conformance_tests.py
+++ b/tools/fog-local-network/fog_conformance_tests.py
@@ -262,7 +262,7 @@ class FogConformanceTest:
     def fresh_balance_check(self, name, key_num, acceptable_answers, expected_eventual_block_count):
         for ebc in expected_eventual_block_count:
             assert ebc in acceptable_answers
-        print(f"Checking account {key_num}...")
+        print(f"Checking account {key_num} on {name}...")
         start_time = time.perf_counter()
         prog = BalanceCheckProgram(
             name = name,
@@ -306,7 +306,7 @@ class FogConformanceTest:
     def follow_up_balance_check(self, prog, acceptable_answers, expected_eventual_block_count):
         for ebc in expected_eventual_block_count:
             assert ebc in acceptable_answers
-        print(f"Checking account {prog.key_num}...")
+        print(f"Checking account {prog.key_num} on {prog.name}...")
         start_time = time.perf_counter()
         result = prog.check()
         while True:

--- a/tools/fog-local-network/fog_conformance_tests.py
+++ b/tools/fog-local-network/fog_conformance_tests.py
@@ -535,23 +535,16 @@ class FogConformanceTest:
         wallet3_from4a = self.fresh_balance_check("from4a", 3, {4: 20}, [4])
         wallet4_from4a = self.fresh_balance_check("from4a", 4, {4: 1}, [4])
 
-        self.follow_up_balance_check(wallet0_from1, {4: 5}, [4])
-        self.follow_up_balance_check(wallet1_from1, {4: 1}, [4])
-        self.follow_up_balance_check(wallet2_from1, {4: 1}, [4])
-        self.follow_up_balance_check(wallet3_from1, {4: 20}, [4])
-        self.follow_up_balance_check(wallet4_from1, {4: 1}, [4])
-
-        self.follow_up_balance_check(wallet0_from2, {4: 5}, [4])
-        self.follow_up_balance_check(wallet1_from2, {4: 1}, [4])
-        self.follow_up_balance_check(wallet2_from2, {4: 1}, [4])
-        self.follow_up_balance_check(wallet3_from2, {4: 20}, [4])
-        self.follow_up_balance_check(wallet4_from2, {4: 1}, [4])
-
-        self.follow_up_balance_check(wallet0_from3a, {4: 5}, [4])
-        self.follow_up_balance_check(wallet1_from3a, {4: 1}, [4])
-        self.follow_up_balance_check(wallet2_from3a, {4: 1}, [4])
-        self.follow_up_balance_check(wallet3_from3a, {4: 20}, [4])
-        self.follow_up_balance_check(wallet4_from3a, {4: 1}, [4])
+        for (wallet0, wallet1, wallet2, wallet3, wallet4) in (
+            (wallet0_from1, wallet1_from1, wallet2_from1, wallet3_from1, wallet4_from1),
+            (wallet0_from2, wallet1_from2, wallet2_from2, wallet3_from2, wallet4_from2),
+            (wallet0_from3a, wallet1_from3a, wallet2_from3a, wallet3_from3a, wallet4_from3a),
+        ):
+            self.follow_up_balance_check(wallet0, {4: 5}, [4])
+            self.follow_up_balance_check(wallet1, {4: 1}, [4])
+            self.follow_up_balance_check(wallet2, {4: 1}, [4])
+            self.follow_up_balance_check(wallet3, {4: 20}, [4])
+            self.follow_up_balance_check(wallet4, {4: 1}, [4])
 
         # Add block 4 to ingest
         ledger1.add_block(credits4, key_images4, fog_pubkey)
@@ -564,23 +557,16 @@ class FogConformanceTest:
         wallet3_from5 = self.fresh_balance_check("from5", 3, {4: 20, 5: 0}, [5])
         wallet4_from5 = self.fresh_balance_check("from5", 4, {4: 1, 5: 0}, [5])
 
-        self.follow_up_balance_check(wallet0_from1, {5: 10}, [5])
-        self.follow_up_balance_check(wallet1_from1, {5: 6}, [5])
-        self.follow_up_balance_check(wallet2_from1, {5: 0}, [5])
-        self.follow_up_balance_check(wallet3_from1, {5: 0}, [5])
-        self.follow_up_balance_check(wallet4_from1, {5: 0}, [5])
-
-        self.follow_up_balance_check(wallet0_from4, {5: 10}, [5])
-        self.follow_up_balance_check(wallet1_from4, {5: 6}, [5])
-        self.follow_up_balance_check(wallet2_from4, {5: 0}, [5])
-        self.follow_up_balance_check(wallet3_from4, {5: 0}, [5])
-        self.follow_up_balance_check(wallet4_from4, {5: 0}, [5])
-
-        self.follow_up_balance_check(wallet0_from4a, {5: 10}, [5])
-        self.follow_up_balance_check(wallet1_from4a, {5: 6}, [5])
-        self.follow_up_balance_check(wallet2_from4a, {5: 0}, [5])
-        self.follow_up_balance_check(wallet3_from4a, {5: 0}, [5])
-        self.follow_up_balance_check(wallet4_from4a, {5: 0}, [5])
+        for (wallet0, wallet1, wallet2, wallet3, wallet4) in (
+            (wallet0_from1, wallet1_from1, wallet2_from1, wallet3_from1, wallet4_from1),
+            (wallet0_from4, wallet1_from4, wallet2_from4, wallet3_from4, wallet4_from4),
+            (wallet0_from4a, wallet1_from4a, wallet2_from4a, wallet3_from4a, wallet4_from4a),
+        ):
+            self.follow_up_balance_check(wallet0, {5: 10}, [5])
+            self.follow_up_balance_check(wallet1, {5: 6}, [5])
+            self.follow_up_balance_check(wallet2, {5: 0}, [5])
+            self.follow_up_balance_check(wallet3, {5: 0}, [5])
+            self.follow_up_balance_check(wallet4, {5: 0}, [5])
 
         # Add block 5 to ingest only
         # Give 9 to everyone
@@ -603,29 +589,17 @@ class FogConformanceTest:
         wallet3_from5a = self.fresh_balance_check("from5a", 3, {5: 0, 6: 9}, [5, 6])
         wallet4_from5a = self.fresh_balance_check("from5a", 4, {5: 0, 6: 9}, [5, 6])
 
-        self.follow_up_balance_check(wallet0_from1, {5: 10}, [5])
-        self.follow_up_balance_check(wallet1_from1, {5: 6}, [5])
-        self.follow_up_balance_check(wallet2_from1, {5: 0, 6: 9}, [5, 6])
-        self.follow_up_balance_check(wallet3_from1, {5: 0, 6: 9}, [5, 6])
-        self.follow_up_balance_check(wallet4_from1, {5: 0, 6: 9}, [5, 6])
-
-        self.follow_up_balance_check(wallet0_from3a, {5: 10}, [5])
-        self.follow_up_balance_check(wallet1_from3a, {5: 6}, [5])
-        self.follow_up_balance_check(wallet2_from3a, {5: 0, 6: 9}, [5, 6])
-        self.follow_up_balance_check(wallet3_from3a, {5: 0, 6: 9}, [5, 6])
-        self.follow_up_balance_check(wallet4_from3a, {5: 0, 6: 9}, [5, 6])
-
-        self.follow_up_balance_check(wallet0_from4, {5: 10}, [5])
-        self.follow_up_balance_check(wallet1_from4, {5: 6}, [5])
-        self.follow_up_balance_check(wallet2_from4, {5: 0, 6: 9}, [5, 6])
-        self.follow_up_balance_check(wallet3_from4, {5: 0, 6: 9}, [5, 6])
-        self.follow_up_balance_check(wallet4_from4, {5: 0, 6: 9}, [5, 6])
-
-        self.follow_up_balance_check(wallet0_from4a, {5: 10}, [5])
-        self.follow_up_balance_check(wallet1_from4a, {5: 6}, [5])
-        self.follow_up_balance_check(wallet2_from4a, {5: 0, 6: 9}, [5, 6])
-        self.follow_up_balance_check(wallet3_from4a, {5: 0, 6: 9}, [5, 6])
-        self.follow_up_balance_check(wallet4_from4a, {5: 0, 6: 9}, [5, 6])
+        for (wallet0, wallet1, wallet2, wallet3, wallet4) in (
+            (wallet0_from1, wallet1_from1, wallet2_from1, wallet3_from1, wallet4_from1),
+            (wallet0_from3a, wallet1_from3a, wallet2_from3a, wallet3_from3a, wallet4_from3a),
+            (wallet0_from4, wallet1_from4, wallet2_from4, wallet3_from4, wallet4_from4),
+            (wallet0_from4a, wallet1_from4a, wallet2_from4a, wallet3_from4a, wallet4_from4a),
+        ):
+            self.follow_up_balance_check(wallet0, {5: 10}, [5])
+            self.follow_up_balance_check(wallet1, {5: 6}, [5])
+            self.follow_up_balance_check(wallet2, {5: 0, 6: 9}, [5, 6])
+            self.follow_up_balance_check(wallet3, {5: 0, 6: 9}, [5, 6])
+            self.follow_up_balance_check(wallet4, {5: 0, 6: 9}, [5, 6])
 
         # Add block 6 to ingest only
         # Give 1 to everyone
@@ -644,23 +618,16 @@ class FogConformanceTest:
         wallet3_from6a = self.fresh_balance_check("from6a", 3, {5: 0, 6: 9}, [5, 6])
         wallet4_from6a = self.fresh_balance_check("from6a", 4, {5: 0, 6: 9}, [5, 6])
 
-        self.follow_up_balance_check(wallet0_from1, {5: 10}, [5])
-        self.follow_up_balance_check(wallet1_from1, {5: 6}, [5])
-        self.follow_up_balance_check(wallet2_from1, {5: 0, 6: 9}, [5, 6])
-        self.follow_up_balance_check(wallet3_from1, {5: 0, 6: 9}, [5, 6])
-        self.follow_up_balance_check(wallet4_from1, {5: 0, 6: 9}, [5, 6])
-
-        self.follow_up_balance_check(wallet0_from3a, {5: 10}, [5])
-        self.follow_up_balance_check(wallet1_from3a, {5: 6}, [5])
-        self.follow_up_balance_check(wallet2_from3a, {5: 0, 6: 9}, [5, 6])
-        self.follow_up_balance_check(wallet3_from3a, {5: 0, 6: 9}, [5, 6])
-        self.follow_up_balance_check(wallet4_from3a, {5: 0, 6: 9}, [5, 6])
-
-        self.follow_up_balance_check(wallet0_from4, {5: 10}, [5])
-        self.follow_up_balance_check(wallet1_from4, {5: 6}, [5])
-        self.follow_up_balance_check(wallet2_from4, {5: 0, 6: 9}, [5, 6])
-        self.follow_up_balance_check(wallet3_from4, {5: 0, 6: 9}, [5, 6])
-        self.follow_up_balance_check(wallet4_from4, {5: 0, 6: 9}, [5, 6])
+        for (wallet0, wallet1, wallet2, wallet3, wallet4) in (
+            (wallet0_from1, wallet1_from1, wallet2_from1, wallet3_from1, wallet4_from1),
+            (wallet0_from3a, wallet1_from3a, wallet2_from3a, wallet3_from3a, wallet4_from3a),
+            (wallet0_from4, wallet1_from4, wallet2_from4, wallet3_from4, wallet4_from4),
+        ):
+            self.follow_up_balance_check(wallet0, {5: 10}, [5])
+            self.follow_up_balance_check(wallet1, {5: 6}, [5])
+            self.follow_up_balance_check(wallet2, {5: 0, 6: 9}, [5, 6])
+            self.follow_up_balance_check(wallet3, {5: 0, 6: 9}, [5, 6])
+            self.follow_up_balance_check(wallet4, {5: 0, 6: 9}, [5, 6])
 
         # Add block 5 to ledger
         ledger2.add_block(credits5, key_images5, fog_pubkey)
@@ -673,29 +640,17 @@ class FogConformanceTest:
         wallet3_from6b = self.fresh_balance_check("from6b", 3, {5: 0, 6: 9}, [6])
         wallet4_from6b = self.fresh_balance_check("from6b", 4, {5: 0, 6: 9}, [6])
 
-        self.follow_up_balance_check(wallet0_from1, {6: 12}, [6])
-        self.follow_up_balance_check(wallet1_from1, {6: 11}, [6])
-        self.follow_up_balance_check(wallet2_from1, {6: 9}, [6])
-        self.follow_up_balance_check(wallet3_from1, {6: 9}, [6])
-        self.follow_up_balance_check(wallet4_from1, {6: 9}, [6])
-
-        self.follow_up_balance_check(wallet0_from4, {6: 12}, [6])
-        self.follow_up_balance_check(wallet1_from4, {6: 11}, [6])
-        self.follow_up_balance_check(wallet2_from4, {6: 9}, [6])
-        self.follow_up_balance_check(wallet3_from4, {6: 9}, [6])
-        self.follow_up_balance_check(wallet4_from4, {6: 9}, [6])
-
-        self.follow_up_balance_check(wallet0_from4a, {6: 12}, [6])
-        self.follow_up_balance_check(wallet1_from4a, {6: 11}, [6])
-        self.follow_up_balance_check(wallet2_from4a, {6: 9}, [6])
-        self.follow_up_balance_check(wallet3_from4a, {6: 9}, [6])
-        self.follow_up_balance_check(wallet4_from4a, {6: 9}, [6])
-
-        self.follow_up_balance_check(wallet0_from5a, {6: 12}, [6])
-        self.follow_up_balance_check(wallet1_from5a, {6: 11}, [6])
-        self.follow_up_balance_check(wallet2_from5a, {6: 9}, [6])
-        self.follow_up_balance_check(wallet3_from5a, {6: 9}, [6])
-        self.follow_up_balance_check(wallet4_from5a, {6: 9}, [6])
+        for (wallet0, wallet1, wallet2, wallet3, wallet4) in (
+            (wallet0_from1, wallet1_from1, wallet2_from1, wallet3_from1, wallet4_from1),
+            (wallet0_from4, wallet1_from4, wallet2_from4, wallet3_from4, wallet4_from4),
+            (wallet0_from4a, wallet1_from4a, wallet2_from4a, wallet3_from4a, wallet4_from4a),
+            (wallet0_from5a, wallet1_from5a, wallet2_from5a, wallet3_from5a, wallet4_from5a),
+        ):
+            self.follow_up_balance_check(wallet0, {6: 12}, [6])
+            self.follow_up_balance_check(wallet1, {6: 11}, [6])
+            self.follow_up_balance_check(wallet2, {6: 9}, [6])
+            self.follow_up_balance_check(wallet3, {6: 9}, [6])
+            self.follow_up_balance_check(wallet4, {6: 9}, [6])
 
         # Add block 7 to ingest only
         # Add 4 to 4,
@@ -714,29 +669,17 @@ class FogConformanceTest:
         wallet3_from7a = self.fresh_balance_check("from7a", 3, {6: 9}, [6])
         wallet4_from7a = self.fresh_balance_check("from7a", 4, {6: 9}, [6])
 
-        self.follow_up_balance_check(wallet0_from1, {6: 12}, [6])
-        self.follow_up_balance_check(wallet1_from1, {6: 11}, [6])
-        self.follow_up_balance_check(wallet2_from1, {6: 9}, [6])
-        self.follow_up_balance_check(wallet3_from1, {6: 9}, [6])
-        self.follow_up_balance_check(wallet4_from1, {6: 9}, [6])
-
-        self.follow_up_balance_check(wallet0_from3, {6: 12}, [6])
-        self.follow_up_balance_check(wallet1_from3, {6: 11}, [6])
-        self.follow_up_balance_check(wallet2_from3, {6: 9}, [6])
-        self.follow_up_balance_check(wallet3_from3, {6: 9}, [6])
-        self.follow_up_balance_check(wallet4_from3, {6: 9}, [6])
-
-        self.follow_up_balance_check(wallet0_from4, {6: 12}, [6])
-        self.follow_up_balance_check(wallet1_from4, {6: 11}, [6])
-        self.follow_up_balance_check(wallet2_from4, {6: 9}, [6])
-        self.follow_up_balance_check(wallet3_from4, {6: 9}, [6])
-        self.follow_up_balance_check(wallet4_from4, {6: 9}, [6])
-
-        self.follow_up_balance_check(wallet0_from4a, {6: 12}, [6])
-        self.follow_up_balance_check(wallet1_from4a, {6: 11}, [6])
-        self.follow_up_balance_check(wallet2_from4a, {6: 9}, [6])
-        self.follow_up_balance_check(wallet3_from4a, {6: 9}, [6])
-        self.follow_up_balance_check(wallet4_from4a, {6: 9}, [6])
+        for (wallet0, wallet1, wallet2, wallet3, wallet4) in (
+            (wallet0_from1, wallet1_from1, wallet2_from1, wallet3_from1, wallet4_from1),
+            (wallet0_from3, wallet1_from3, wallet2_from3, wallet3_from3, wallet4_from3),
+            (wallet0_from4, wallet1_from4, wallet2_from4, wallet3_from4, wallet4_from4),
+            (wallet0_from4a, wallet1_from4a, wallet2_from4a, wallet3_from4a, wallet4_from4a),
+        ):
+            self.follow_up_balance_check(wallet0, {6: 12}, [6])
+            self.follow_up_balance_check(wallet1, {6: 11}, [6])
+            self.follow_up_balance_check(wallet2, {6: 9}, [6])
+            self.follow_up_balance_check(wallet3, {6: 9}, [6])
+            self.follow_up_balance_check(wallet4, {6: 9}, [6])
 
         # Add block 6 to ledger
         ledger2.add_block(credits6, key_images6, fog_pubkey)
@@ -749,29 +692,22 @@ class FogConformanceTest:
         wallet3_from7b = self.fresh_balance_check("from7b", 3, {6: 9, 7: 1}, [7])
         wallet4_from7b = self.fresh_balance_check("from7b", 4, {6: 9, 7: 10}, [7])
 
-        self.follow_up_balance_check(wallet0_from1, {7: 13}, [7])
-        self.follow_up_balance_check(wallet1_from1, {7: 10}, [7])
-        self.follow_up_balance_check(wallet2_from1, {7: 10}, [7])
-        self.follow_up_balance_check(wallet3_from1, {7: 1}, [7])
-        self.follow_up_balance_check(wallet4_from1, {7: 10}, [7])
-
-        self.follow_up_balance_check(wallet0_from4, {7: 13}, [7])
-        self.follow_up_balance_check(wallet1_from4, {7: 10}, [7])
-        self.follow_up_balance_check(wallet2_from4, {7: 10}, [7])
-        self.follow_up_balance_check(wallet3_from4, {7: 1}, [7])
-        self.follow_up_balance_check(wallet4_from4, {7: 10}, [7])
-
-        self.follow_up_balance_check(wallet0_from4a, {7: 13}, [7])
-        self.follow_up_balance_check(wallet1_from4a, {7: 10}, [7])
-        self.follow_up_balance_check(wallet2_from4a, {7: 10}, [7])
-        self.follow_up_balance_check(wallet3_from4a, {7: 1}, [7])
-        self.follow_up_balance_check(wallet4_from4a, {7: 10}, [7])
-
-        self.follow_up_balance_check(wallet0_from6a, {7: 13}, [7])
-        self.follow_up_balance_check(wallet1_from6a, {7: 10}, [7])
-        self.follow_up_balance_check(wallet2_from6a, {7: 10}, [7])
-        self.follow_up_balance_check(wallet3_from6a, {7: 1}, [7])
-        self.follow_up_balance_check(wallet4_from6a, {7: 10}, [7])
+        for (wallet0, wallet1, wallet2, wallet3, wallet4) in (
+            (wallet0_from1, wallet1_from1, wallet2_from1, wallet3_from1, wallet4_from1),
+            (wallet0_from2, wallet1_from2, wallet2_from2, wallet3_from2, wallet4_from2),
+            (wallet0_from3, wallet1_from3, wallet2_from3, wallet3_from3, wallet4_from3),
+            (wallet0_from3a, wallet1_from3a, wallet2_from3a, wallet3_from3a, wallet4_from3a),
+            (wallet0_from4, wallet1_from4, wallet2_from4, wallet3_from4, wallet4_from4),
+            (wallet0_from4a, wallet1_from4a, wallet2_from4a, wallet3_from4a, wallet4_from4a),
+            (wallet0_from5, wallet1_from5, wallet2_from5, wallet3_from5, wallet4_from5),
+            (wallet0_from5a, wallet1_from5a, wallet2_from5a, wallet3_from5a, wallet4_from5a),
+            (wallet0_from6a, wallet1_from6a, wallet2_from6a, wallet3_from6a, wallet4_from6a),
+        ):
+            self.follow_up_balance_check(wallet0, {7: 13}, [7])
+            self.follow_up_balance_check(wallet1, {7: 10}, [7])
+            self.follow_up_balance_check(wallet2, {7: 10}, [7])
+            self.follow_up_balance_check(wallet3, {7: 1}, [7])
+            self.follow_up_balance_check(wallet4, {7: 10}, [7])
 
         # Add block 7 to ledger
         ledger2.add_block(credits7, key_images7, fog_pubkey)
@@ -784,77 +720,25 @@ class FogConformanceTest:
         wallet3_from7c = self.fresh_balance_check("from7c", 3, {7: 1, 8: 1}, [8])
         wallet4_from7c = self.fresh_balance_check("from7c", 4, {7: 10, 8: 14}, [8])
 
-        self.follow_up_balance_check(wallet0_from1, {8: 13}, [8])
-        self.follow_up_balance_check(wallet1_from1, {8: 10}, [8])
-        self.follow_up_balance_check(wallet2_from1, {8: 1}, [8])
-        self.follow_up_balance_check(wallet3_from1, {8: 1}, [8])
-        self.follow_up_balance_check(wallet4_from1, {8: 14}, [8])
-
-        self.follow_up_balance_check(wallet0_from2, {8: 13}, [8])
-        self.follow_up_balance_check(wallet1_from2, {8: 10}, [8])
-        self.follow_up_balance_check(wallet2_from2, {8: 1}, [8])
-        self.follow_up_balance_check(wallet3_from2, {8: 1}, [8])
-        self.follow_up_balance_check(wallet4_from2, {8: 14}, [8])
-
-        self.follow_up_balance_check(wallet0_from3, {8: 13}, [8])
-        self.follow_up_balance_check(wallet1_from3, {8: 10}, [8])
-        self.follow_up_balance_check(wallet2_from3, {8: 1}, [8])
-        self.follow_up_balance_check(wallet3_from3, {8: 1}, [8])
-        self.follow_up_balance_check(wallet4_from3, {8: 14}, [8])
-
-        self.follow_up_balance_check(wallet0_from3a, {8: 13}, [8])
-        self.follow_up_balance_check(wallet1_from3a, {8: 10}, [8])
-        self.follow_up_balance_check(wallet2_from3a, {8: 1}, [8])
-        self.follow_up_balance_check(wallet3_from3a, {8: 1}, [8])
-        self.follow_up_balance_check(wallet4_from3a, {8: 14}, [8])
-
-        self.follow_up_balance_check(wallet0_from4, {8: 13}, [8])
-        self.follow_up_balance_check(wallet1_from4, {8: 10}, [8])
-        self.follow_up_balance_check(wallet2_from4, {8: 1}, [8])
-        self.follow_up_balance_check(wallet3_from4, {8: 1}, [8])
-        self.follow_up_balance_check(wallet4_from4, {8: 14}, [8])
-
-        self.follow_up_balance_check(wallet0_from4a, {8: 13}, [8])
-        self.follow_up_balance_check(wallet1_from4a, {8: 10}, [8])
-        self.follow_up_balance_check(wallet2_from4a, {8: 1}, [8])
-        self.follow_up_balance_check(wallet3_from4a, {8: 1}, [8])
-        self.follow_up_balance_check(wallet4_from4a, {8: 14}, [8])
-
-        self.follow_up_balance_check(wallet0_from5, {8: 13}, [8])
-        self.follow_up_balance_check(wallet1_from5, {8: 10}, [8])
-        self.follow_up_balance_check(wallet2_from5, {8: 1}, [8])
-        self.follow_up_balance_check(wallet3_from5, {8: 1}, [8])
-        self.follow_up_balance_check(wallet4_from5, {8: 14}, [8])
-
-        self.follow_up_balance_check(wallet0_from5a, {8: 13}, [8])
-        self.follow_up_balance_check(wallet1_from5a, {8: 10}, [8])
-        self.follow_up_balance_check(wallet2_from5a, {8: 1}, [8])
-        self.follow_up_balance_check(wallet3_from5a, {8: 1}, [8])
-        self.follow_up_balance_check(wallet4_from5a, {8: 14}, [8])
-
-        self.follow_up_balance_check(wallet0_from6a, {8: 13}, [8])
-        self.follow_up_balance_check(wallet1_from6a, {8: 10}, [8])
-        self.follow_up_balance_check(wallet2_from6a, {8: 1}, [8])
-        self.follow_up_balance_check(wallet3_from6a, {8: 1}, [8])
-        self.follow_up_balance_check(wallet4_from6a, {8: 14}, [8])
-
-        self.follow_up_balance_check(wallet0_from6b, {8: 13}, [8])
-        self.follow_up_balance_check(wallet1_from6b, {8: 10}, [8])
-        self.follow_up_balance_check(wallet2_from6b, {8: 1}, [8])
-        self.follow_up_balance_check(wallet3_from6b, {8: 1}, [8])
-        self.follow_up_balance_check(wallet4_from6b, {8: 14}, [8])
-
-        self.follow_up_balance_check(wallet0_from7a, {8: 13}, [8])
-        self.follow_up_balance_check(wallet1_from7a, {8: 10}, [8])
-        self.follow_up_balance_check(wallet2_from7a, {8: 1}, [8])
-        self.follow_up_balance_check(wallet3_from7a, {8: 1}, [8])
-        self.follow_up_balance_check(wallet4_from7a, {8: 14}, [8])
-
-        self.follow_up_balance_check(wallet0_from7b, {8: 13}, [8])
-        self.follow_up_balance_check(wallet1_from7b, {8: 10}, [8])
-        self.follow_up_balance_check(wallet2_from7b, {8: 1}, [8])
-        self.follow_up_balance_check(wallet3_from7b, {8: 1}, [8])
-        self.follow_up_balance_check(wallet4_from7b, {8: 14}, [8])
+        for (wallet0, wallet1, wallet2, wallet3, wallet4) in (
+            (wallet0_from1, wallet1_from1, wallet2_from1, wallet3_from1, wallet4_from1),
+            (wallet0_from2, wallet1_from2, wallet2_from2, wallet3_from2, wallet4_from2),
+            (wallet0_from3, wallet1_from3, wallet2_from3, wallet3_from3, wallet4_from3),
+            (wallet0_from3a, wallet1_from3a, wallet2_from3a, wallet3_from3a, wallet4_from3a),
+            (wallet0_from4, wallet1_from4, wallet2_from4, wallet3_from4, wallet4_from4),
+            (wallet0_from4a, wallet1_from4a, wallet2_from4a, wallet3_from4a, wallet4_from4a),
+            (wallet0_from5, wallet1_from5, wallet2_from5, wallet3_from5, wallet4_from5),
+            (wallet0_from5a, wallet1_from5a, wallet2_from5a, wallet3_from5a, wallet4_from5a),
+            (wallet0_from6a, wallet1_from6a, wallet2_from6a, wallet3_from6a, wallet4_from6a),
+            (wallet0_from6b, wallet1_from6b, wallet2_from6b, wallet3_from6b, wallet4_from6b),
+            (wallet0_from7a, wallet1_from7a, wallet2_from7a, wallet3_from7a, wallet4_from7a),
+            (wallet0_from7b, wallet1_from7b, wallet2_from7b, wallet3_from7b, wallet4_from7b),
+        ):
+            self.follow_up_balance_check(wallet0, {8: 13}, [8])
+            self.follow_up_balance_check(wallet1, {8: 10}, [8])
+            self.follow_up_balance_check(wallet2, {8: 1}, [8])
+            self.follow_up_balance_check(wallet3, {8: 1}, [8])
+            self.follow_up_balance_check(wallet4, {8: 14}, [8])
 
         #######################################################################
         # Test what happens if we introduce a second ingest server and retire
@@ -932,6 +816,27 @@ class FogConformanceTest:
         wallet2_from9 = self.fresh_balance_check("from9", 2, {9: 3, 10: 4}, [10])
         wallet3_from9 = self.fresh_balance_check("from9", 3, {9: 3, 10: 4}, [10])
         wallet4_from9 = self.fresh_balance_check("from9", 4, {9: 12, 10: 13}, [10])
+
+        for (wallet0, wallet1, wallet2, wallet3, wallet4) in (
+            (wallet0_from1, wallet1_from1, wallet2_from1, wallet3_from1, wallet4_from1),
+            (wallet0_from2, wallet1_from2, wallet2_from2, wallet3_from2, wallet4_from2),
+            (wallet0_from3, wallet1_from3, wallet2_from3, wallet3_from3, wallet4_from3),
+            (wallet0_from3a, wallet1_from3a, wallet2_from3a, wallet3_from3a, wallet4_from3a),
+            (wallet0_from4, wallet1_from4, wallet2_from4, wallet3_from4, wallet4_from4),
+            (wallet0_from4a, wallet1_from4a, wallet2_from4a, wallet3_from4a, wallet4_from4a),
+            (wallet0_from5, wallet1_from5, wallet2_from5, wallet3_from5, wallet4_from5),
+            (wallet0_from5a, wallet1_from5a, wallet2_from5a, wallet3_from5a, wallet4_from5a),
+            (wallet0_from6a, wallet1_from6a, wallet2_from6a, wallet3_from6a, wallet4_from6a),
+            (wallet0_from6b, wallet1_from6b, wallet2_from6b, wallet3_from6b, wallet4_from6b),
+            (wallet0_from7a, wallet1_from7a, wallet2_from7a, wallet3_from7a, wallet4_from7a),
+            (wallet0_from7b, wallet1_from7b, wallet2_from7b, wallet3_from7b, wallet4_from7b),
+            (wallet0_from8, wallet1_from8, wallet2_from8, wallet3_from8, wallet4_from8),
+        ):
+            self.follow_up_balance_check(wallet0, {9: 15, 10: 14}, [10])
+            self.follow_up_balance_check(wallet1, {9: 12, 10: 13}, [10])
+            self.follow_up_balance_check(wallet2, {9: 3, 10: 4}, [10])
+            self.follow_up_balance_check(wallet3, {9: 3, 10: 4}, [10])
+            self.follow_up_balance_check(wallet4, {9: 12, 10: 13}, [10])
 
         # Ingest1 should now be retired, ingest2 should still be active
         status = self.fog_ingest.get_status()

--- a/tools/fog-local-network/fog_conformance_tests.py
+++ b/tools/fog-local-network/fog_conformance_tests.py
@@ -801,7 +801,7 @@ class FogConformanceTest:
 
         # Add block 9 to ingest and ledger. This should cause ingest1 to become Idle.
         # Give 1 to everyone
-        # Take 2 from ???
+        # Take 2 from wallet0
         credits9 = [{'account': 0, 'amount': 1}, {'account': 1, 'amount': 1}, {'account': 2, 'amount': 1}, {'account': 3, 'amount': 1}, {'account': 4, 'amount': 1}]
         key_images9 = [block8_key_images[0]]
         print("Key images spent in Block 9: ", key_images9)

--- a/tools/fog-local-network/local_fog.py
+++ b/tools/fog-local-network/local_fog.py
@@ -1,5 +1,6 @@
-# Copyright (c) 2018-2020 MobileCoin Inc.
+# Copyright (c) 2018-2021 MobileCoin Inc.
 
+import json
 import os
 import subprocess
 
@@ -80,7 +81,7 @@ class FogIngest:
             f'--peer-listen-uri=insecure-igp://localhost:{self.peer_port}/',
             f'--ias-api-key={IAS_API_KEY}',
             f'--ias-spid={IAS_SPID}',
-            f'--local-node-id localhost:{self.client_port}',
+            f'--local-node-id localhost:{self.peer_port}',
             f'--state-file {self.state_file_path}',
             f'--admin-listen-uri=insecure-mca://127.0.0.1:{self.admin_port}/',
             f'--watcher-db {self.watcher_db_path}',
@@ -109,6 +110,57 @@ class FogIngest:
         if self.admin_http_gateway_process and self.admin_http_gateway_process.poll() is None:
             self.admin_http_gateway_process.terminate()
             self.admin_http_gateway_process = None
+
+    def get_status(self):
+        cmd = ' '.join([
+            f'exec {FOG_PROJECT_DIR}/{target_dir(self.release)}/fog_ingest_client',
+            f'--uri insecure-fog-ingest://localhost:{self.client_port}',
+            'get-status',
+        ])
+        print(cmd)
+        result = subprocess.check_output(cmd, shell=True)
+        return json.loads(result)
+
+    def activate(self):
+        cmd = ' '.join([
+            f'exec {FOG_PROJECT_DIR}/{target_dir(self.release)}/fog_ingest_client',
+            f'--uri insecure-fog-ingest://localhost:{self.client_port}',
+            'activate',
+        ])
+        print(cmd)
+        result = subprocess.check_output(cmd, shell=True)
+        return json.loads(result)
+
+    def set_pubkey_expiry_window(self, value):
+        cmd = ' '.join([
+            f'exec {FOG_PROJECT_DIR}/{target_dir(self.release)}/fog_ingest_client',
+            f'--uri insecure-fog-ingest://localhost:{self.client_port}',
+            'set-pubkey-expiry-window',
+            str(value),
+        ])
+        print(cmd)
+        result = subprocess.check_output(cmd, shell=True)
+        return json.loads(result)
+
+    def set_peers(self, peers):
+        cmd = ' '.join([
+            f'exec {FOG_PROJECT_DIR}/{target_dir(self.release)}/fog_ingest_client',
+            f'--uri insecure-fog-ingest://localhost:{self.client_port}',
+            'set-peers',
+        ] + peers)
+        print(cmd)
+        result = subprocess.check_output(cmd, shell=True)
+        return json.loads(result)
+
+    def retire(self):
+        cmd = ' '.join([
+            f'exec {FOG_PROJECT_DIR}/{target_dir(self.release)}/fog_ingest_client',
+            f'--uri insecure-fog-ingest://localhost:{self.client_port}',
+            'retire',
+        ])
+        print(cmd)
+        result = subprocess.check_output(cmd, shell=True)
+        return json.loads(result)
 
 
 class FogView:


### PR DESCRIPTION
Soundtrack of this PR: https://soundcloud.com/janoma/janoma-live-sisyphos-the-bronny-bounce

### Motivation

Currently conformance tests only utilize a single ingest server. We want to make the tests more elaborate and have them cover multiple scenarios that involve numerous ingest servers. This PR is the first step in that direction.

### In this PR
* Change fog ingest client utility to output JSON ingest summary data and consume it in the Python code
* Uprev `mobilecoin`
* Add a test that spawns a 2nd ingest server, instructs the 1st one to retire, send transactions using the second server's ingest key and verify they are found using the test client.

### Future Work
* More elaborate tests.

