### PR TITLE
DRY/clean up parts of fog conformance tests

### DIFF
--- a/tools/fog-local-network/fog_conformance_tests.py
+++ b/tools/fog-local-network/fog_conformance_tests.py
@@ -316,11 +316,11 @@ class MultiBalanceTester:
         self.steps.append(new_wallets)
 
     def stop(self):
-        for wallets in self.balance_checkers:
+        for wallets in self.steps:
             for balance_checker in wallets:
                 balance_checker.stop()
 
-        self.balance_checkers = []
+        self.steps = []
 
     # Make a fresh balance_check program, and check that it computes an expected balance
     #


### PR DESCRIPTION
### Motivation

The Fog conformance test script was getting longer and contained a bunch of repeated code to deal with the over-increasing list of clients we are testing with. Each step would start a new balance check client to perform fresh balance checks while also performing balance checks with all the previously-started clients. The list was maintained by hand which is annoying and unnecessary.

### In this PR
* Create a new `MutliBalanceChecker` object that handles the collection of clients and is capable of performing a balance check on all of them.
* Some cleanups of the "credits" part of the test to make it more readable - each account is on its own lines instead of all accounts mishmashed in one long line.

### Future Work
* Figure out a way to make the script use pytest or some other testing framework in order to make it easier to write multiple tests that are independent of each-other (as opposed to the current single test that is an assortment of steps that build on top of each other). 

