### PR TITLE
[SWIFT-164] Add support for slip10 key derivation to LibMobileCoin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2413,6 +2413,7 @@ dependencies = [
  "fog-kex-rng 0.13.0",
  "libc 0.2.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "mc-account-keys 1.0.1-pre1",
+ "mc-account-keys-slip10 1.0.1-pre1",
  "mc-api 1.0.1-pre1",
  "mc-attest-ake 1.0.1-pre1",
  "mc-attest-core 1.0.1-pre1",
@@ -2554,6 +2555,21 @@ dependencies = [
  "mc-util-serial 1.0.1-pre1",
  "prost 0.6.1 (git+https://github.com/danburkert/prost?rev=6113789f70b69709820becba4242824b4fb3ffec)",
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zeroize 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "mc-account-keys-slip10"
+version = "1.0.1-pre1"
+dependencies = [
+ "curve25519-dalek 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "displaydoc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hkdf 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mc-account-keys 1.0.1-pre1",
+ "mc-crypto-keys 1.0.1-pre1",
+ "sha2 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slip10_ed25519 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tiny-bip39 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zeroize 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,7 +115,7 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.28"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -264,20 +264,6 @@ dependencies = [
  "shlex 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "which 3.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "bip39"
-version = "1.0.0-rc1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "bitcoin_hashes 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-normalization 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "bitcoin_hashes"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "bitflags"
@@ -766,7 +752,7 @@ dependencies = [
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.118 (registry+https://github.com/rust-lang/crates.io-index)",
  "subtle 2.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zeroize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zeroize 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -900,7 +886,7 @@ dependencies = [
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.118 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "zeroize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zeroize 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1171,7 +1157,7 @@ dependencies = [
  "mc-util-serial 1.0.1-pre1",
  "mc-util-test-helper 1.0.1-pre1",
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "zeroize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zeroize 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1550,7 +1536,7 @@ dependencies = [
  "structopt 0.3.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "x509-signature 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zeroize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zeroize 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1839,7 +1825,7 @@ dependencies = [
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_hc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.118 (registry+https://github.com/rust-lang/crates.io-index)",
- "zeroize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zeroize 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2293,7 +2279,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-normalization 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-normalization 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2421,7 +2407,6 @@ name = "libmobilecoin"
 version = "0.13.0"
 dependencies = [
  "aes-gcm 0.6.0 (git+https://github.com/mobilecoinofficial/AEADs?rev=d1a8517d3dd867ed9c5794002add67992a42f6aa)",
- "bip39 1.0.0-rc1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cbindgen 0.14.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "cmake 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "displaydoc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2447,7 +2432,8 @@ dependencies = [
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "slip10_ed25519 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "zeroize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tiny-bip39 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zeroize 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2568,7 +2554,7 @@ dependencies = [
  "mc-util-serial 1.0.1-pre1",
  "prost 0.6.1 (git+https://github.com/danburkert/prost?rev=6113789f70b69709820becba4242824b4fb3ffec)",
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "zeroize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zeroize 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2576,7 +2562,7 @@ name = "mc-android-bindings"
 version = "0.13.0"
 dependencies = [
  "aes-gcm 0.6.0 (git+https://github.com/mobilecoinofficial/AEADs?rev=d1a8517d3dd867ed9c5794002add67992a42f6aa)",
- "bip39 1.0.0-rc1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "anyhow 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "displaydoc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fog-kex-rng 0.13.0",
  "jni 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2601,7 +2587,8 @@ dependencies = [
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "slip10_ed25519 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "zeroize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tiny-bip39 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zeroize 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3049,7 +3036,7 @@ dependencies = [
  "sha2 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "signature 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "x25519-dalek 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zeroize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zeroize 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3082,7 +3069,7 @@ dependencies = [
  "serde 1.0.118 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "subtle 2.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zeroize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zeroize 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3550,7 +3537,7 @@ dependencies = [
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.118 (registry+https://github.com/rust-lang/crates.io-index)",
  "subtle 2.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zeroize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zeroize 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3585,7 +3572,7 @@ dependencies = [
  "prost 0.6.1 (git+https://github.com/danburkert/prost?rev=6113789f70b69709820becba4242824b4fb3ffec)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "zeroize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zeroize 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3706,7 +3693,7 @@ dependencies = [
  "sha2 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "signal-hook 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "subtle 2.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zeroize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zeroize 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3878,7 +3865,7 @@ dependencies = [
  "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "keccak 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "zeroize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zeroize 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -4060,6 +4047,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "once_cell"
 version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "parking_lot 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "oorandom"
@@ -4106,6 +4096,14 @@ dependencies = [
  "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "pbkdf2"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crypto-mac 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -4296,7 +4294,7 @@ dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "spin 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -4313,7 +4311,7 @@ name = "prost-derive"
 version = "0.6.1"
 source = "git+https://github.com/danburkert/prost?rev=6113789f70b69709820becba4242824b4fb3ffec#6113789f70b69709820becba4242824b4fb3ffec"
 dependencies = [
- "anyhow 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "anyhow 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4761,7 +4759,7 @@ dependencies = [
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "subtle 2.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zeroize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zeroize 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -4783,7 +4781,7 @@ name = "secrecy"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "zeroize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zeroize 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -5081,14 +5079,6 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "0.6.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "maybe-uninit 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "smallvec"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
@@ -5273,15 +5263,15 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.20"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "thiserror-impl 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror-impl 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.20"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5342,6 +5332,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiny-bip39"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "anyhow 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hmac 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "once_cell 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pbkdf2 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-hash 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha2 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-normalization 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zeroize 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "tinytemplate"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5349,6 +5356,19 @@ dependencies = [
  "serde 1.0.118 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.60 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "tinyvec"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "tinyvec_macros 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "tokio"
@@ -5445,10 +5465,10 @@ dependencies = [
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.9"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "smallvec 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tinyvec 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -5727,7 +5747,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "curve25519-dalek 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "zeroize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zeroize 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -5746,7 +5766,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "zeroize"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "zeroize_derive 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5777,7 +5797,7 @@ dependencies = [
 "checksum aligned-array 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e05c92d086290f52938013f6242ac62bf7d401fab8ad36798a609faa65c3fd2c"
 "checksum aligned-cmov 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "58430584a6379af5673f32a3d2bb95915d7cdfb33137697c3dc14de2397dbf24"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
-"checksum anyhow 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)" = "d9a60d744a80c30fcb657dfe2c1b22bcb3e814c1a1e3674f32bf5820b570fbff"
+"checksum anyhow 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)" = "28b2cd92db5cbd74e8e5028f7e27dd7aa3090e89e4f2a197cc7c8dfb69c7063b"
 "checksum arc-swap 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "dabe5a181f83789739c194cbe5a897dde195078fac08568d09221fd6137a7ba8"
 "checksum arrayref 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
 "checksum arrayvec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8"
@@ -5795,8 +5815,6 @@ dependencies = [
 "checksum bigint 4.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c0e8c8a600052b52482eff2cf4d810e462fdff1f656ac1ecb6232132a1ed7def"
 "checksum binascii 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "383d29d513d8764dcdc42ea295d979eb99c3c9f00607b3692cf68a431f7dca72"
 "checksum bindgen 0.51.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ebd71393f1ec0509b553aa012b9b58e81dadbdff7130bd3b8cba576e69b32f75"
-"checksum bip39 1.0.0-rc1 (registry+https://github.com/rust-lang/crates.io-index)" = "74754271d6ea9def32223d8febf6dbba06172a50887e1babd8b8621415107f43"
-"checksum bitcoin_hashes 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "b375d62f341cef9cd9e77793ec8f1db3fc9ce2e4d57e982c8fe697a2c16af3b6"
 "checksum bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 "checksum bitmaps 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "031043d04099746d8db04daf1fa424b2bc8bd69d92b25962dcde24da39ab64a2"
 "checksum blake2 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "10a5720225ef5daecf08657f23791354e1685a8c91a4c60c7f3d3b2892f978f4"
@@ -5982,6 +6000,7 @@ dependencies = [
 "checksum packed_simd 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a85ea9fc0d4ac0deb6fe7911d38786b32fc11119afd9e9d38b84ff691ce64220"
 "checksum parking_lot 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a4893845fa2ca272e647da5d0e46660a314ead9c2fdd9a883aabc32e481a8733"
 "checksum parking_lot_core 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c361aa727dd08437f2f1447be8b59a33b0edd15e0fcee698f935613d9efbca9b"
+"checksum pbkdf2 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "216eaa586a190f0a738f2f918511eecfa90f13295abec0e457cdebcceda80cbd"
 "checksum peeking_take_while 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 "checksum pem 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f4c220d01f863d13d96ca82359d1e81e64a7c6bf0637bcde7b2349630addf0c6"
 "checksum percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
@@ -6088,7 +6107,6 @@ dependencies = [
 "checksum slog-scope 4.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7c44c89dd8b0ae4537d1ae318353eaf7840b4869c536e31c41e963d1ea523ee6"
 "checksum slog-stdlog 4.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8228ab7302adbf4fcb37e66f3cda78003feb521e7fd9e3847ec117a7784d0f5a"
 "checksum slog-term 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bab1d807cf71129b05ce36914e1dbb6fbfbdecaf686301cb457f4fa967f9f5b6"
-"checksum smallvec 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)" = "b97fcaeba89edba30f044a10c6a3cc39df9c3f17d7cd829dd1446cab35f890e0"
 "checksum smallvec 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "fbee7696b84bbf3d89a1c2eccff0850e3047ed46bfcd2e92c29a2d074d57e252"
 "checksum spin 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 "checksum standback 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "47e4b8c631c998468961a9ea159f064c5c8499b95b5e4a34b77849d45949d540"
@@ -6110,14 +6128,17 @@ dependencies = [
 "checksum term 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c0863a3345e70f61d613eab32ee046ccd1bcc5f9105fe402c61fcd0c13eeb8b5"
 "checksum termcolor 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb6bfa289a4d7c5766392812c0a1f4c1ba45afa1ad47803c11e1f407d846d75f"
 "checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-"checksum thiserror 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)" = "7dfdd070ccd8ccb78f4ad66bf1982dc37f620ef696c6b5028fe2ed83dd3d0d08"
-"checksum thiserror-impl 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)" = "bd80fc12f73063ac132ac92aceea36734f04a1d93c1240c6944e23a3b8841793"
+"checksum thiserror 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)" = "e0f4a65597094d4483ddaed134f409b2cb7c1beccf25201a9f73c719254fa98e"
+"checksum thiserror-impl 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)" = "7765189610d8241a44529806d6fd1f2e0a08734313a35d5b3a556f92b381f3c0"
 "checksum thread_local 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
 "checksum time 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
 "checksum time 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)" = "55b7151c9065e80917fbf285d9a5d1432f60db41d170ccafc749a136b41a93af"
 "checksum time-macros 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "957e9c6e26f12cb6d0dd7fc776bb67a706312e7299aed74c8dd5b17ebb27e2f1"
 "checksum time-macros-impl 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e5c3be1edfad6027c69f5491cf4cb310d1a71ecd6af742788c6ff8bced86b8fa"
+"checksum tiny-bip39 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d9e44c4759bae7f1032e286a7ef990bd9ed23fe831b7eeba0beb97484c2e59b8"
 "checksum tinytemplate 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "45e4bc5ac99433e0dcb8b9f309dd271a165ae37dde129b9e0ce1bfdd8bfe4891"
+"checksum tinyvec 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "317cca572a0e89c3ce0ca1f1bdc9369547fe318a683418e42ac8f59d14701023"
+"checksum tinyvec_macros 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 "checksum tokio 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)" = "05c1d570eb1a36f0345a5ce9c6c6e665b70b73d11236912c0b477616aeec47b1"
 "checksum tokio-rustls 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4adb8b3e5f86b707f1b54e7c15b6de52617a823608ccda98a15d3a24222f265a"
 "checksum tokio-util 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "be8242891f2b6cbef26a2d7e8605133c2c554cd35b3e4948ea892d6d68436499"
@@ -6129,7 +6150,7 @@ dependencies = [
 "checksum uname 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b72f89f0ca32e4db1c04e2a72f5345d59796d4866a1ee0609084569f73683dc8"
 "checksum unicase 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
 "checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
-"checksum unicode-normalization 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "09c8070a9942f5e7cfccd93f490fdebd230ee3c3c9f107cb25bad5351ef671cf"
+"checksum unicode-normalization 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)" = "07fbfce1c8a97d547e8b5334978438d9d6ec8c20e38f56d4a4374d181493eaef"
 "checksum unicode-segmentation 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0"
 "checksum unicode-width 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
@@ -6169,5 +6190,5 @@ dependencies = [
 "checksum x25519-dalek 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc614d95359fd7afc321b66d2107ede58b246b844cf5d8a0adcca413e439f088"
 "checksum x509-signature 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9fb2bc2a902d992cd5f471ee3ab0ffd6603047a4207384562755b9d6de977518"
 "checksum yasna 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "79af3189e6b0484c9fd54208f8eeb8818cadee00ec81438b67a64c8e6f2f3694"
-"checksum zeroize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3cbac2ed2ba24cc90f5e06485ac8c7c1e5449fe8911aef4d8877218af021a5b8"
+"checksum zeroize 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "81a974bcdd357f0dca4d41677db03436324d45a4c9ed2d0b873a5a360ce41c36"
 "checksum zeroize_derive 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "de251eec69fc7c1bc3923403d18ececb929380e016afe103da75f396704f8ca2"

--- a/android-bindings/Cargo.toml
+++ b/android-bindings/Cargo.toml
@@ -34,11 +34,12 @@ mc-util-uri = { path = "../mobilecoin/util/uri" }
 mc-api = { path = "../mobilecoin/api" }
 
 aes-gcm = { version = "0.6", default-features = false }
-bip39 = "1.0.0-rc1"
+anyhow = "1.0"
 displaydoc = { version = "0.2", default-features = false }
 jni = { version = "0.16.0", default-features = false }
 protobuf = "2.12"
 rand = { version = "0.7", default-features = false }
 sha2 = { version = "0.9", default-features = false }
 slip10_ed25519 = "0.1.3"
+tiny-bip39 = "0.8"
 zeroize = "1.1"

--- a/libmobilecoin/Cargo.toml
+++ b/libmobilecoin/Cargo.toml
@@ -11,13 +11,13 @@ crate-type = ["lib", "staticlib", "cdylib"]
 [dependencies]
 # External dependencies
 aes-gcm = "0.6"
-bip39 = "1.0.0-rc1"
 displaydoc = "0.2"
 libc = "0.2"
 protobuf = "2.12"
 rand_core = { version = "0.5", features = ["std"] }
 sha2 = "0.9"
 slip10_ed25519 = "0.1.3"
+tiny-bip39 = "0.8"
 zeroize = "1.1"
 
 # Lock cmake-rs verson since only 0.1.43 currently supports ios

--- a/libmobilecoin/Cargo.toml
+++ b/libmobilecoin/Cargo.toml
@@ -28,6 +28,7 @@ cmake = "= 0.1.43"
 # MobileCoin dependencies
 fog-kex-rng = { path = "../fog/kex_rng" }
 mc-account-keys = { path = "../mobilecoin/account-keys" }
+mc-account-keys-slip10 = { path = "../mobilecoin/account-keys/slip10" }
 mc-api = { path = "../mobilecoin/api" }
 mc-attest-ake = { path = "../mobilecoin/attest/ake" }
 mc-attest-core = { path = "../mobilecoin/attest/core" }

--- a/libmobilecoin/include/bip39.h
+++ b/libmobilecoin/include/bip39.h
@@ -13,43 +13,12 @@ extern "C" {
 
 /// # Preconditions
 ///
-/// * `mnemonic` - must be a nul-terminated C string containing valid UTF-8.
-/// * `out_entropy` - must be null or else length must be >= `entropy.len`.
-///
-/// # Errors
-///
-/// * `LibMcError::InvalidInput`
-ssize_t mc_bip39_entropy_from_mnemonic(
-  const char* MC_NONNULL mnemonic,
-  McMutableBuffer* MC_NULLABLE out_entropy,
-  McError* MC_NULLABLE * MC_NULLABLE out_error
-)
-MC_ATTRIBUTE_NONNULL(1);
-
-/// # Preconditions
-///
-/// * `entropy` - length must be a multiple of 4 and between 16 and 32, inclusive.
-char* MC_NULLABLE mc_bip39_entropy_to_mnemonic(
+/// * `entropy` - length must be a multiple of 4 and between 16 and 32,
+///   inclusive, in bytes.
+char* MC_NULLABLE mc_bip39_mnemonic_from_entropy(
   const McBuffer* MC_NONNULL entropy
 )
 MC_ATTRIBUTE_NONNULL(1);
-
-/// # Preconditions
-///
-/// * `mnemonic` - must be a nul-terminated C string containing valid UTF-8.
-/// * `passphrase` - must be a nul-terminated C string containing valid UTF-8. Can be empty.
-/// * `out_seed` - length must be >= 64.
-///
-/// # Errors
-///
-/// * `LibMcError::InvalidInput`
-bool mc_bip39_get_seed(
-  const char* MC_NONNULL mnemonic,
-  const char* MC_NONNULL  passphrase,
-  McMutableBuffer* MC_NONNULL out_seed,
-  McError* MC_NULLABLE * MC_NULLABLE out_error
-)
-MC_ATTRIBUTE_NONNULL(1, 2, 3);
 
 /// # Preconditions
 ///

--- a/libmobilecoin/include/keys.h
+++ b/libmobilecoin/include/keys.h
@@ -41,18 +41,6 @@ typedef struct {
 
 /// # Preconditions
 ///
-/// * `root_entropy` - must be 32 bytes in length.
-/// * `out_view_private_key` - length must be >= 32.
-/// * `out_spend_private_key` - length must be >= 32.
-bool mc_account_private_keys_from_root_entropy(
-  const McBuffer* MC_NONNULL root_entropy,
-  McMutableBuffer* MC_NONNULL out_view_private_key,
-  McMutableBuffer* MC_NONNULL out_spend_private_key
-)
-MC_ATTRIBUTE_NONNULL(1, 2, 3);
-
-/// # Preconditions
-///
 /// * `view_private_key` - must be a valid 32-byte Ristretto-format scalar.
 /// * `spend_private_key` - must be a valid 32-byte Ristretto-format scalar.
 /// * `out_subaddress_view_private_key` - length must be >= 32.

--- a/libmobilecoin/include/slip10.h
+++ b/libmobilecoin/include/slip10.h
@@ -9,35 +9,25 @@
 extern "C" {
 #endif
 
-/* ==== Types ==== */
-
-typedef struct _McSlip10Indices McSlip10Indices;
-
-/* ==== McSlip10Indices ==== */
-
-McSlip10Indices* MC_NULLABLE mc_slip10_indices_create(void);
-
-void mc_slip10_indices_free(
-  McSlip10Indices* MC_NULLABLE indices
-);
-
-bool mc_slip10_indices_add(
-  McSlip10Indices* MC_NONNULL indices,
-  uint32_t index
-)
-MC_ATTRIBUTE_NONNULL(1);
-
 /* ==== McSlip10 ==== */
 
 /// # Preconditions
 ///
-/// * `out_key` - length must be >= 32.
-bool mc_slip10_derive_ed25519_private_key(
-  const McBuffer* MC_NONNULL seed,
-  const McSlip10Indices* MC_NONNULL path,
-  McMutableBuffer* MC_NONNULL out_key
+/// * `mnemonic` - must be a nul-terminated C string containing valid UTF-8.
+/// * `out_view_private_key` - length must be >= 32.
+/// * `out_spend_private_key` - length must be >= 32.
+///
+/// # Errors
+///
+/// * `LibMcError::InvalidInput`
+bool mc_slip10_account_private_keys_from_mnemonic(
+  const char* MC_NONNULL mnemonic,
+  uint32_t account_index,
+  McMutableBuffer* MC_NONNULL out_view_private_key,
+  McMutableBuffer* MC_NONNULL out_spend_private_key,
+  McError* MC_NULLABLE * MC_NULLABLE out_error
 )
-MC_ATTRIBUTE_NONNULL(1, 2, 3);
+MC_ATTRIBUTE_NONNULL(1, 3, 4);
 
 #ifdef __cplusplus
 }

--- a/libmobilecoin/libmobilecoin_cbindgen.h
+++ b/libmobilecoin/libmobilecoin_cbindgen.h
@@ -32,8 +32,6 @@ typedef struct McTransactionBuilderRing McTransactionBuilderRing;
 
 typedef struct Option_TransactionBuilder_FogResolver Option_TransactionBuilder_FogResolver;
 
-typedef struct Vec_u32 Vec_u32;
-
 typedef struct Vec_u8 Vec_u8;
 
 typedef struct Vec_u8 McData;
@@ -115,8 +113,6 @@ typedef struct McAccountKey {
   FfiRefPtr<McBuffer> spend_private_key;
   FfiOptRefPtr<McAccountKeyFogInfo> fog_info;
 } McAccountKey;
-
-typedef struct Vec_u32 McSlip10Indices;
 
 typedef struct McTxOutAmount {
   /**
@@ -354,41 +350,10 @@ ssize_t mc_attest_ake_decrypt(FfiMutPtr<McAttestAke> attest_ake,
 /**
  * # Preconditions
  *
- * * `mnemonic` - must be a nul-terminated C string containing valid UTF-8.
- * * `out_entropy` - must be null or else length must be >= `entropy.len`.
- *
- * # Errors
- *
- * * `LibMcError::InvalidInput`
- */
-ssize_t mc_bip39_entropy_from_mnemonic(FfiStr mnemonic,
-                                       FfiOptMutPtr<McMutableBuffer> out_entropy,
-                                       FfiOptMutPtr<FfiOptOwnedPtr<McError>> out_error);
-
-/**
- * # Preconditions
- *
  * * `entropy` - length must be a multiple of 4 and between 16 and 32,
- *   inclusive.
+ *   inclusive, in bytes.
  */
-FfiOptOwnedStr mc_bip39_entropy_to_mnemonic(FfiRefPtr<McBuffer> entropy);
-
-/**
- * # Preconditions
- *
- * * `mnemonic` - must be a nul-terminated C string containing valid UTF-8.
- * * `passphrase` - must be a nul-terminated C string containing valid UTF-8.
- *   Can be empty.
- * * `out_seed` - length must be >= 64.
- *
- * # Errors
- *
- * * `LibMcError::InvalidInput`
- */
-bool mc_bip39_get_seed(FfiStr mnemonic,
-                       FfiStr passphrase,
-                       FfiMutPtr<McMutableBuffer> out_seed,
-                       FfiOptMutPtr<FfiOptOwnedPtr<McError>> out_error);
+FfiOptOwnedStr mc_bip39_mnemonic_from_entropy(FfiRefPtr<McBuffer> entropy);
 
 /**
  * # Preconditions
@@ -547,17 +512,6 @@ bool mc_fog_rng_advance(FfiMutPtr<McFogRng> fog_rng, FfiOptMutPtr<McMutableBuffe
 /**
  * # Preconditions
  *
- * * `root_entropy` - must be 32 bytes in length.
- * * `out_view_private_key` - length must be >= 32.
- * * `out_spend_private_key` - length must be >= 32.
- */
-bool mc_account_private_keys_from_root_entropy(FfiRefPtr<McBuffer> root_entropy,
-                                               FfiMutPtr<McMutableBuffer> out_view_private_key,
-                                               FfiMutPtr<McMutableBuffer> out_spend_private_key);
-
-/**
- * # Preconditions
- *
  * * `view_private_key` - must be a valid 32-byte Ristretto-format scalar.
  * * `spend_private_key` - must be a valid 32-byte Ristretto-format scalar.
  * * `out_subaddress_view_private_key` - length must be >= 32.
@@ -593,20 +547,22 @@ bool mc_account_key_get_public_address_fog_authority_sig(FfiRefPtr<McAccountKey>
                                                          uint64_t subaddress_index,
                                                          FfiMutPtr<McMutableBuffer> out_fog_authority_sig);
 
-FfiOptOwnedPtr<McSlip10Indices> mc_slip10_indices_create(void);
-
-void mc_slip10_indices_free(FfiOptOwnedPtr<McSlip10Indices> indices);
-
-bool mc_slip10_indices_add(FfiMutPtr<McSlip10Indices> indices, uint32_t index);
-
 /**
  * # Preconditions
  *
- * * `out_key` - length must be >= 32.
+ * * `mnemonic` - must be a nul-terminated C string containing valid UTF-8.
+ * * `out_view_private_key` - length must be >= 32.
+ * * `out_spend_private_key` - length must be >= 32.
+ *
+ * # Errors
+ *
+ * * `LibMcError::InvalidInput`
  */
-bool mc_slip10_derive_ed25519_private_key(FfiRefPtr<McBuffer> seed,
-                                          FfiRefPtr<McSlip10Indices> path,
-                                          FfiMutPtr<McMutableBuffer> out_key);
+bool mc_slip10_account_private_keys_from_mnemonic(FfiStr mnemonic,
+                                                  uint32_t account_index,
+                                                  FfiMutPtr<McMutableBuffer> out_view_private_key,
+                                                  FfiMutPtr<McMutableBuffer> out_spend_private_key,
+                                                  FfiOptMutPtr<FfiOptOwnedPtr<McError>> out_error);
 
 /**
  * # Preconditions

--- a/libmobilecoin/src/bip39.rs
+++ b/libmobilecoin/src/bip39.rs
@@ -1,91 +1,20 @@
 // Copyright 2018-2021 The MobileCoin Foundation
 
-use crate::{common::*, LibMcError};
-use bip39::{Language, Mnemonic, Seed};
-use libc::ssize_t;
+use crate::common::*;
+use bip39::{Language, Mnemonic};
 use mc_util_ffi::*;
 
 /// # Preconditions
 ///
-/// * `mnemonic` - must be a nul-terminated C string containing valid UTF-8.
-/// * `out_entropy` - must be null or else length must be >= `entropy.len`.
-///
-/// # Errors
-///
-/// * `LibMcError::InvalidInput`
-#[no_mangle]
-pub extern "C" fn mc_bip39_entropy_from_mnemonic(
-    mnemonic: FfiStr,
-    out_entropy: FfiOptMutPtr<McMutableBuffer>,
-    out_error: FfiOptMutPtr<FfiOptOwnedPtr<McError>>,
-) -> ssize_t {
-    ffi_boundary_with_error(out_error, || {
-        let mnemonic = String::try_from_ffi(mnemonic).expect("mnemonic is invalid");
-
-        let mnemonic = Mnemonic::from_phrase(&mnemonic, Language::English)
-            .map_err(|err| LibMcError::InvalidInput(format!("Invalid mnemonic: {}", err)))?;
-        let entropy = mnemonic.entropy();
-
-        if let Some(out_entropy) = out_entropy.into_option() {
-            let out_entropy = out_entropy
-                .into_mut()
-                .as_slice_mut_of_len(entropy.len())
-                .expect("out_entropy length is insufficient");
-            out_entropy.copy_from_slice(&entropy);
-        }
-
-        Ok(ssize_t::ffi_try_from(entropy.len())
-            .expect("entropy.len() could not be converted to ssize_t"))
-    })
-}
-
-/// # Preconditions
-///
 /// * `entropy` - length must be a multiple of 4 and between 16 and 32,
-///   inclusive.
+///   inclusive, in bytes.
 #[no_mangle]
-pub extern "C" fn mc_bip39_entropy_to_mnemonic(entropy: FfiRefPtr<McBuffer>) -> FfiOptOwnedStr {
+pub extern "C" fn mc_bip39_mnemonic_from_entropy(entropy: FfiRefPtr<McBuffer>) -> FfiOptOwnedStr {
     ffi_boundary(|| {
         let mnemonic = Mnemonic::from_entropy(&entropy, Language::English)
             .expect("entropy could not be converted to a mnemonic");
         FfiOwnedStr::ffi_try_from(mnemonic.to_string())
             .expect("mnemonic could not be converted to a C string")
-    })
-}
-
-/// # Preconditions
-///
-/// * `mnemonic` - must be a nul-terminated C string containing valid UTF-8.
-/// * `passphrase` - must be a nul-terminated C string containing valid UTF-8.
-///   Can be empty.
-/// * `out_seed` - length must be >= 64.
-///
-/// # Errors
-///
-/// * `LibMcError::InvalidInput`
-#[no_mangle]
-pub extern "C" fn mc_bip39_get_seed(
-    mnemonic: FfiStr,
-    passphrase: FfiStr,
-    out_seed: FfiMutPtr<McMutableBuffer>,
-    out_error: FfiOptMutPtr<FfiOptOwnedPtr<McError>>,
-) -> bool {
-    ffi_boundary_with_error(out_error, || {
-        let mnemonic = String::try_from_ffi(mnemonic).expect("mnemonic is invalid");
-        let passphrase = String::try_from_ffi(passphrase).expect("passphrase is invalid");
-
-        let mnemonic = Mnemonic::from_phrase(&mnemonic, Language::English)
-            .map_err(|err| LibMcError::InvalidInput(format!("Invalid mnemonic: {}", err)))?;
-        let seed = Seed::new(&mnemonic, &passphrase);
-
-        let out_seed = out_seed
-            .into_mut()
-            .as_slice_mut_of_len(seed.as_bytes().len())
-            .expect("out_seed length is insufficient");
-
-        out_seed.copy_from_slice(seed.as_bytes());
-
-        Ok(())
     })
 }
 

--- a/libmobilecoin/src/keys.rs
+++ b/libmobilecoin/src/keys.rs
@@ -1,7 +1,7 @@
 // Copyright 2018-2021 The MobileCoin Foundation
 
 use crate::{common::*, LibMcError};
-use mc_account_keys::{AccountKey, PublicAddress, RootIdentity};
+use mc_account_keys::{AccountKey, PublicAddress};
 use mc_crypto_keys::{ReprBytes, RistrettoPrivate, RistrettoPublic};
 use mc_util_ffi::*;
 
@@ -42,35 +42,6 @@ impl<'a> TryFromFfi<&McAccountKey<'a>> for AccountKey {
             Ok(AccountKey::new(&spend_private_key, &view_private_key))
         }
     }
-}
-
-/// # Preconditions
-///
-/// * `root_entropy` - must be 32 bytes in length.
-/// * `out_view_private_key` - length must be >= 32.
-/// * `out_spend_private_key` - length must be >= 32.
-#[no_mangle]
-pub extern "C" fn mc_account_private_keys_from_root_entropy(
-    root_entropy: FfiRefPtr<McBuffer>,
-    out_view_private_key: FfiMutPtr<McMutableBuffer>,
-    out_spend_private_key: FfiMutPtr<McMutableBuffer>,
-) -> bool {
-    ffi_boundary(|| {
-        let root_entropy = <&[u8; 32]>::try_from_ffi(&root_entropy)
-            .expect("root_entropy must be 32 bytes in length");
-        let out_view_private_key = out_view_private_key
-            .into_mut()
-            .as_slice_mut_of_len(RistrettoPrivate::size())
-            .expect("out_view_private_key length is insufficient");
-        let out_spend_private_key = out_spend_private_key
-            .into_mut()
-            .as_slice_mut_of_len(RistrettoPrivate::size())
-            .expect("out_spend_private_key length is insufficient");
-
-        let account_key = AccountKey::from(&RootIdentity::from(root_entropy));
-        out_view_private_key.copy_from_slice(account_key.view_private_key().as_ref());
-        out_spend_private_key.copy_from_slice(account_key.spend_private_key().as_ref());
-    })
 }
 
 /// # Preconditions


### PR DESCRIPTION
### Motivation

The new MobileCoin mnemonic key derivation spec is based on SLIP-10. This PR adds support for it to LibMobileCoin.

Note: It removes support for the old, deprecated derivation method (using "root entropy"). This is okay because LibMobileCoin is in a beta/prerelease state and isn't yet used in production in an clients.

### In this PR

* Adds support for slip10 key derivation to LibMobileCoin
* Upgrades `mc-android-bindings` from using `bip39` to using `tiny-bip39`.

