### PR TITLE
Restore mnemonic to BIP-39 entropy conversion in LibMobileCoin

### DIFF
--- a/libmobilecoin/include/bip39.h
+++ b/libmobilecoin/include/bip39.h
@@ -22,6 +22,21 @@ MC_ATTRIBUTE_NONNULL(1);
 
 /// # Preconditions
 ///
+/// * `mnemonic` - must be a nul-terminated C string containing valid UTF-8.
+/// * `out_entropy` - must be null or else length must be >= `entropy.len`.
+///
+/// # Errors
+///
+/// * `LibMcError::InvalidInput`
+ssize_t mc_bip39_entropy_from_mnemonic(
+  const char* MC_NONNULL mnemonic,
+  McMutableBuffer* MC_NULLABLE out_entropy,
+  McError* MC_NULLABLE * MC_NULLABLE out_error
+)
+MC_ATTRIBUTE_NONNULL(1);
+
+/// # Preconditions
+///
 /// * `prefix` - must be a nul-terminated C string containing valid UTF-8.
 char* MC_NULLABLE mc_bip39_words_by_prefix(
   const char* MC_NONNULL prefix

--- a/libmobilecoin/libmobilecoin_cbindgen.h
+++ b/libmobilecoin/libmobilecoin_cbindgen.h
@@ -358,6 +358,20 @@ FfiOptOwnedStr mc_bip39_mnemonic_from_entropy(FfiRefPtr<McBuffer> entropy);
 /**
  * # Preconditions
  *
+ * * `mnemonic` - must be a nul-terminated C string containing valid UTF-8.
+ * * `out_entropy` - must be null or else length must be >= `entropy.len`.
+ *
+ * # Errors
+ *
+ * * `LibMcError::InvalidInput`
+ */
+ssize_t mc_bip39_entropy_from_mnemonic(FfiStr mnemonic,
+                                       FfiOptMutPtr<McMutableBuffer> out_entropy,
+                                       FfiOptMutPtr<FfiOptOwnedPtr<McError>> out_error);
+
+/**
+ * # Preconditions
+ *
  * * `prefix` - must be a nul-terminated C string containing valid UTF-8.
  */
 FfiOptOwnedStr mc_bip39_words_by_prefix(FfiStr prefix);

--- a/libmobilecoin/src/bip39.rs
+++ b/libmobilecoin/src/bip39.rs
@@ -1,7 +1,8 @@
 // Copyright 2018-2021 The MobileCoin Foundation
 
-use crate::common::*;
+use crate::{common::*, LibMcError};
 use bip39::{Language, Mnemonic};
+use libc::ssize_t;
 use mc_util_ffi::*;
 
 /// # Preconditions
@@ -20,12 +21,45 @@ pub extern "C" fn mc_bip39_mnemonic_from_entropy(entropy: FfiRefPtr<McBuffer>) -
 
 /// # Preconditions
 ///
+/// * `mnemonic` - must be a nul-terminated C string containing valid UTF-8.
+/// * `out_entropy` - must be null or else length must be >= `entropy.len`.
+///
+/// # Errors
+///
+/// * `LibMcError::InvalidInput`
+#[no_mangle]
+pub extern "C" fn mc_bip39_entropy_from_mnemonic(
+    mnemonic: FfiStr,
+    out_entropy: FfiOptMutPtr<McMutableBuffer>,
+    out_error: FfiOptMutPtr<FfiOptOwnedPtr<McError>>,
+) -> ssize_t {
+    ffi_boundary_with_error(out_error, || {
+        let mnemonic = <&str>::try_from_ffi(mnemonic).expect("mnemonic is invalid");
+
+        let mnemonic = Mnemonic::from_phrase(mnemonic, Language::English)
+            .map_err(|err| LibMcError::InvalidInput(format!("Invalid mnemonic: {}", err)))?;
+        let entropy = mnemonic.entropy();
+
+        if let Some(out_entropy) = out_entropy.into_option() {
+            let out_entropy = out_entropy
+                .into_mut()
+                .as_slice_mut_of_len(entropy.len())
+                .expect("out_entropy length is insufficient");
+            out_entropy.copy_from_slice(&entropy);
+        }
+        Ok(ssize_t::ffi_try_from(entropy.len())
+            .expect("entropy.len() could not be converted to ssize_t"))
+    })
+}
+
+/// # Preconditions
+///
 /// * `prefix` - must be a nul-terminated C string containing valid UTF-8.
 #[no_mangle]
 pub extern "C" fn mc_bip39_words_by_prefix(prefix: FfiStr) -> FfiOptOwnedStr {
     ffi_boundary(|| {
-        let prefix = String::try_from_ffi(prefix).expect("prefix is invalid");
-        let words = Language::English.wordlist().get_words_by_prefix(&prefix);
+        let prefix = <&str>::try_from_ffi(prefix).expect("prefix is invalid");
+        let words = Language::English.wordlist().get_words_by_prefix(prefix);
         let joined_words = words.join(",");
         FfiOwnedStr::ffi_try_from(joined_words)
             .expect("joined_words could not be converted to a C string")

--- a/libmobilecoin/src/slip10.rs
+++ b/libmobilecoin/src/slip10.rs
@@ -25,9 +25,9 @@ pub extern "C" fn mc_slip10_account_private_keys_from_mnemonic(
     out_error: FfiOptMutPtr<FfiOptOwnedPtr<McError>>,
 ) -> bool {
     ffi_boundary_with_error(out_error, || {
-        let mnemonic_phrase = String::try_from_ffi(mnemonic).expect("mnemonic is invalid");
+        let mnemonic = <&str>::try_from_ffi(mnemonic).expect("mnemonic is invalid");
 
-        let mnemonic = Mnemonic::from_phrase(&mnemonic_phrase, Language::English)
+        let mnemonic = Mnemonic::from_phrase(mnemonic, Language::English)
             .map_err(|err| LibMcError::InvalidInput(format!("Invalid mnemonic: {}", err)))?;
         let key = mnemonic.derive_slip10_key(account_index);
         let account_key = AccountKey::from(key);


### PR DESCRIPTION
### Motivation

This PR restores the `mc_bip39_entropy_from_mnemonic` function in LibMobileCoin so that bidirectional conversion between BIP-39 entropy and the corresponding mnemonic can be performed.