### PR TITLE
Local fog unified fog URI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -365,7 +365,7 @@ commands:
             export LEDGER_ENCLAVE_PRIVKEY=$(pwd)/mobilecoin/Enclave_private.pem
             export VIEW_ENCLAVE_PRIVKEY=$(pwd)/mobilecoin/Enclave_private.pem
 
-            apt-get update && apt-get install -y python3-venv
+            apt-get update && apt-get install -y python3-venv nginx
             cd tools/fog-local-network
             python3 -m venv env
             . ./env/bin/activate

--- a/fog/sample-paykit/proto/remote_wallet.proto
+++ b/fog/sample-paykit/proto/remote_wallet.proto
@@ -35,11 +35,8 @@ message FreshBalanceCheckRequest {
     /// Root entropy for the account the new client will be using.
     bytes root_entropy = 1;
 
-    /// View server URI
-    string view_server_uri = 2;
-
-    /// Ledger server URI
-    string ledger_server_uri = 3;
+    /// FOG URI (should have view and ledger servers accessible).
+    string fog_uri = 2;
 }
 
 message BalanceCheckResponse {

--- a/fog/sample-paykit/src/bin/sample_paykit_remote_wallet.rs
+++ b/fog/sample-paykit/src/bin/sample_paykit_remote_wallet.rs
@@ -92,17 +92,13 @@ impl RemoteWalletService {
         let fog_uri = request.get_fog_uri();
         let (fog_view_uri, fog_ledger_uri) = if fog_uri.starts_with("fog://") {
             (
-                fog_uri.replace("fog://", "fog-view://").to_string(),
-                fog_uri.replace("fog://", "fog-ledger://").to_string(),
+                fog_uri.replace("fog://", "fog-view://"),
+                fog_uri.replace("fog://", "fog-ledger://"),
             )
         } else if fog_uri.starts_with("insecure-fog://") {
             (
-                fog_uri
-                    .replace("insecure-fog://", "insecure-fog-view://")
-                    .to_string(),
-                fog_uri
-                    .replace("insecure-fog://", "insecure-fog-ledger://")
-                    .to_string(),
+                fog_uri.replace("insecure-fog://", "insecure-fog-view://"),
+                fog_uri.replace("insecure-fog://", "insecure-fog-ledger://"),
             )
         } else {
             return Err(rpc_internal_error(

--- a/tools/fog-local-network/README.md
+++ b/tools/fog-local-network/README.md
@@ -58,17 +58,14 @@ In order to use it, the following steps are necessary.
     # Create a set of target keys. They would be identical to the first N keys inside `keys/`. This is needed if you don't
     # want to send to transactions to all 1000 keys created at step 1.
     # Notice the addition of the --output-dir argument
-    cargo run -p mc-util-keyfile --bin sample-keys --release --manifest-path ../mobilecoin/Cargo.toml -- --num 10 --output-dir fog_keys --fog-report-url 'insecure-fog://localhost:6200'
-
-    # Run fog ingest client
-    SGX_MODE=SW IAS_MODE=DEV cargo run -p fog-ingest-client --release -- --uri insecure-fog-ingest://localhost:4200/ add-users --keys-path ./fog_keys
+    cargo run -p mc-util-keyfile --bin sample-keys --release --manifest-path ../mobilecoin/Cargo.toml -- --num 10 --output-dir fog_keys --fog-report-url 'insecure-fog://localhost:6200' --fog-authority-root $(../mobilecoin/target/release/mc-crypto-x509-test-vectors --type=chain --test-name=ok_rsa_head)
 
     # Run the distribution script. This takes awhile and you should see transactions going through by looking at the logs.
     SGX_MODE=SW IAS_MODE=DEV MC_LOG=debug \
-    INGEST_ENCLAVE_PRIVKEY=$(pwd)/../Enclave_private.pem \
-    LEDGER_ENCLAVE_PRIVKEY=$(pwd)/../Enclave_private.pem \
-    VIEW_ENCLAVE_PRIVKEY=$(pwd)/../Enclave_private.pem \
-    CONSENSUS_ENCLAVE_PRIVKEY=$(pwd)/../Enclave_private.pem \
+    INGEST_ENCLAVE_PRIVKEY=$(pwd)/../mobilecoin/Enclave_private.pem \
+    LEDGER_ENCLAVE_PRIVKEY=$(pwd)/../mobilecoin/Enclave_private.pem \
+    VIEW_ENCLAVE_PRIVKEY=$(pwd)/../mobilecoin/Enclave_private.pem \
+    CONSENSUS_ENCLAVE_PRIVKEY=$(pwd)/../mobilecoin/Enclave_private.pem \
         cargo run -p fog-distribution --release -- \
         --sample-data-dir . \
         --peer insecure-mc://localhost:3200/ \
@@ -84,10 +81,10 @@ In order to use it, the following steps are necessary.
 6) When its done, wait for consensus to complete processing the transactions (by looking at the logs). Afterwards you should be able to successfully run the test client:
     ```
     SGX_MODE=SW IAS_MODE=DEV MC_LOG=trace \
-    INGEST_ENCLAVE_PRIVKEY=$(pwd)/../Enclave_private.pem \
-    LEDGER_ENCLAVE_PRIVKEY=$(pwd)/../Enclave_private.pem \
-    VIEW_ENCLAVE_PRIVKEY=$(pwd)/../Enclave_private.pem \
-    CONSENSUS_ENCLAVE_PRIVKEY=$(pwd)/../Enclave_private.pem \
+    INGEST_ENCLAVE_PRIVKEY=$(pwd)/../mobilecoin/Enclave_private.pem \
+    LEDGER_ENCLAVE_PRIVKEY=$(pwd)/../mobilecoin/Enclave_private.pem \
+    VIEW_ENCLAVE_PRIVKEY=$(pwd)/../mobilecoin/Enclave_private.pem \
+    CONSENSUS_ENCLAVE_PRIVKEY=$(pwd)/../mobilecoin/Enclave_private.pem \
         cargo run -p fog-test-client -- \
         --consensus insecure-mc://localhost:3200/ \
         --consensus insecure-mc://localhost:3201/ \
@@ -98,8 +95,8 @@ In order to use it, the following steps are necessary.
         --num-transactions 32 \
         --consensus-wait 300 \
         --transfer-amount 20 \
-        --fog-view insecure-fog-view://localhost:5200 \
-        --fog-ledger insecure-fog-ledger://localhost:7200 \
+        --fog-view insecure-fog-view://localhost:8200 \
+        --fog-ledger insecure-fog-ledger://localhost:8200 \
         --key-dir $(pwd)/fog_keys
     ```
 

--- a/tools/fog-local-network/fog-nginx.conf
+++ b/tools/fog-local-network/fog-nginx.conf
@@ -1,0 +1,33 @@
+worker_processes  5;  ## Default: 1
+error_log  /tmp/fog-nginx-error.log;
+pid        /tmp/fog-nginx-nginx.pid;
+worker_rlimit_nofile 8192;
+daemon off;
+
+events {
+  worker_connections  4096;  ## Default: 1024
+}
+
+
+http {
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent"';
+
+    server {
+        listen FOG_NGINX_PORT http2;
+
+        access_log /tmp/fog-nginx-access.log main;
+     	error_log /tmp/fog-nginx-error.log;
+
+        location /fog_view {
+            grpc_pass grpc://localhost:FOG_VIEW_PORT;
+        }
+        location /fog_ledger {
+            grpc_pass grpc://localhost:FOG_LEDGER_PORT;
+        }
+        location /report {
+            grpc_pass grpc://localhost:FOG_REPORT_PORT;
+        }
+    }
+}

--- a/tools/fog-local-network/fog_conformance_tests.py
+++ b/tools/fog-local-network/fog_conformance_tests.py
@@ -138,12 +138,11 @@ def parse_balance_check_output(line):
 
 
 class RemoteWallet:
-    def __init__(self, name, remote_wallet_host_port, keys_dir, ledger_url, view_url, key_num):
+    def __init__(self, name, remote_wallet_host_port, keys_dir, fog_url, key_num):
         self.name = name
         self.remote_wallet_host_port = remote_wallet_host_port
         self.keys_dir = keys_dir
-        self.ledger_url = ledger_url
-        self.view_url = view_url
+        self.fog_url = fog_url
         self.key_num = key_num
         self.client_id = None
 
@@ -156,8 +155,7 @@ class RemoteWallet:
             stub = remote_wallet_pb2_grpc.RemoteWalletApiStub(channel)
             response = self._retrying_grpc_request(stub.FreshBalanceCheck, remote_wallet_pb2.FreshBalanceCheckRequest(
                 root_entropy=bytes(key['root_entropy']),
-                view_server_uri=self.view_url,
-                ledger_server_uri=self.ledger_url,
+                fog_uri=self.fog_url,
             ))
 
         print(f'Key {self.key_num} started: {response}')
@@ -252,11 +250,10 @@ class MultiBalanceChecker:
     # The number of wallets we are playing with at each step.
     NUM_WALLETS = 5
 
-    def __init__(self, remote_wallet_host_port, keys_dir, fog_ledger, fog_view, skip_followup_balance_checks):
+    def __init__(self, remote_wallet_host_port, keys_dir, fog_nginx, skip_followup_balance_checks):
         self.remote_wallet_host_port = remote_wallet_host_port
         self.keys_dir = keys_dir
-        self.fog_ledger = fog_ledger
-        self.fog_view = fog_view
+        self.fog_nginx = fog_nginx
         self.skip_followup_balance_checks = skip_followup_balance_checks
 
         self.steps = []
@@ -327,8 +324,7 @@ class MultiBalanceChecker:
             name = name,
             remote_wallet_host_port = self.remote_wallet_host_port,
             keys_dir = self.keys_dir,
-            ledger_url = f'insecure-fog-ledger://localhost:{self.fog_ledger.client_port}/',
-            view_url = f'insecure-fog-view://localhost:{self.fog_view.client_port}/',
+            fog_url = f'insecure-fog://localhost:{self.fog_nginx.client_port}/',
             key_num = key_num,
         )
 
@@ -373,6 +369,7 @@ class FogConformanceTest:
         # Remote wallet
         self.remote_wallet_host_port = args.remote_wallet
 
+        self.fog_nginx = None
         self.fog_ingest = None
         self.fog_ingest2 = None
         self.fog_view = None
@@ -435,6 +432,15 @@ class FogConformanceTest:
 
         # Start fog services
         print("Starting fog services...")
+        self.fog_nginx = FogNginx(
+            work_dir = self.work_dir,
+            client_port = BASE_NGINX_CLIENT_PORT,
+            view_port = BASE_VIEW_CLIENT_PORT,
+            ledger_port = BASE_LEDGER_CLIENT_PORT,
+            report_port = BASE_REPORT_CLIENT_PORT,
+        )
+        self.fog_nginx.start()
+
         self.fog_ingest = FogIngest(
             name = 'ingest1',
             work_dir = self.work_dir,
@@ -450,6 +456,7 @@ class FogConformanceTest:
 
         self.fog_view = FogView(
             name = 'view1',
+            client_responder_id = f'localhost:{BASE_NGINX_CLIENT_PORT}',
             client_port = BASE_VIEW_CLIENT_PORT,
             admin_port = BASE_VIEW_ADMIN_PORT,
             admin_http_gateway_port = BASE_VIEW_ADMIN_HTTP_GATEWAY_PORT,
@@ -460,6 +467,7 @@ class FogConformanceTest:
         self.fog_ledger = FogLedger(
             name = 'ledger_server1',
             ledger_db_path = ledger2.ledger_db_path,
+            client_responder_id = f'localhost:{BASE_NGINX_CLIENT_PORT}',
             client_port = BASE_LEDGER_CLIENT_PORT,
             admin_port = BASE_LEDGER_ADMIN_PORT,
             admin_http_gateway_port = BASE_LEDGER_ADMIN_HTTP_GATEWAY_PORT,
@@ -507,8 +515,7 @@ class FogConformanceTest:
         self.multi_balance_checker = MultiBalanceChecker(
             self.remote_wallet_host_port,
             self.keys_dir,
-            self.fog_ledger,
-            self.fog_view,
+            self.fog_nginx,
             skip_followup_balance_checks,
         )
 
@@ -937,6 +944,10 @@ class FogConformanceTest:
         if self.fog_ingest2:
             self.fog_ingest2.stop()
 
+        if self.fog_nginx:
+            self.fog_nginx.stop()
+
+
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Balance check conformance tester')
     parser.add_argument('--skip-build', help='Skip building binaries', action='store_true')
@@ -953,4 +964,7 @@ if __name__ == '__main__':
     os.makedirs(work_dir)
 
     with FogConformanceTest(work_dir, args) as test:
-        test.run(args.skip_followup_balance_checks)
+        try:
+            test.run(args.skip_followup_balance_checks)
+        finally:
+            test.stop()

--- a/tools/fog-local-network/local_fog.py
+++ b/tools/fog-local-network/local_fog.py
@@ -23,6 +23,8 @@ BASE_LEDGER_CLIENT_PORT = 7200
 BASE_LEDGER_ADMIN_PORT = 7400
 BASE_LEDGER_ADMIN_HTTP_GATEWAY_PORT = 7500
 
+BASE_NGINX_CLIENT_PORT = 8200
+
 PROJECT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', 'mobilecoin'))
 FOG_PROJECT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
 
@@ -167,9 +169,10 @@ class FogIngest:
 
 
 class FogView:
-    def __init__(self, name, client_port, admin_port, admin_http_gateway_port, release):
+    def __init__(self, name, client_responder_id, client_port, admin_port, admin_http_gateway_port, release):
         self.name = name
 
+        self.client_responder_id = client_responder_id
         self.client_port = client_port
         self.client_listen_url = f'insecure-fog-view://{LISTEN_HOST}:{self.client_port}/'
 
@@ -190,7 +193,7 @@ class FogView:
         cmd = ' '.join([
             f'cd {FOG_PROJECT_DIR} && DATABASE_URL=postgres://localhost/{FOG_SQL_DATABASE_NAME} exec {target_dir(self.release)}/fog_view_server',
             f'--client-listen-uri={self.client_listen_url}',
-            f'--client-responder-id=localhost:{self.client_port}',
+            f'--client-responder-id={self.client_responder_id}',
             f'--ias-api-key={IAS_API_KEY}',
             f'--ias-spid={IAS_SPID}',
             f'--admin-listen-uri=insecure-mca://{LISTEN_HOST}:{self.admin_port}/',
@@ -278,11 +281,12 @@ class FogReport:
 
 
 class FogLedger:
-    def __init__(self, name, ledger_db_path, client_port, admin_port, admin_http_gateway_port, watcher_db_path, release):
+    def __init__(self, name, ledger_db_path, client_responder_id, client_port, admin_port, admin_http_gateway_port, watcher_db_path, release):
         self.name = name
         self.ledger_db_path = ledger_db_path
         self.watcher_db_path = watcher_db_path
 
+        self.client_responder_id = client_responder_id
         self.client_port = client_port
         self.client_listen_url = f'insecure-fog-ledger://{LISTEN_HOST}:{self.client_port}/'
 
@@ -305,7 +309,7 @@ class FogLedger:
             f'cd {FOG_PROJECT_DIR} && exec {target_dir(self.release)}/ledger_server',
             f'--ledger-db={self.ledger_db_path}',
             f'--client-listen-uri={self.client_listen_url}',
-            f'--client-responder-id=localhost:{self.client_port}',
+            f'--client-responder-id={self.client_responder_id}',
             f'--ias-api-key={IAS_API_KEY}',
             f'--ias-spid={IAS_SPID}',
             f'--admin-listen-uri=insecure-mca://{LISTEN_HOST}:{self.admin_port}/',
@@ -335,3 +339,41 @@ class FogLedger:
         if self.admin_http_gateway_process and self.admin_http_gateway_process.poll() is None:
             self.admin_http_gateway_process.terminate()
             self.admin_http_gateway_process = None
+
+
+class FogNginx:
+    """Starts a local nginx server that routes requests to the different fog servers"""
+    def __init__(self, work_dir, client_port, view_port, ledger_port, report_port):
+        self.client_port = client_port
+        self.conf_file = os.path.join(work_dir, 'fog-nginx.conf')
+        self.nginx_process = None
+
+        # Load the template nginx configuration and search/replace the port numbers
+        template = open(os.path.join(os.path.dirname(__file__), 'fog-nginx.conf'), 'r').read()
+        conf = template.replace(
+            'FOG_NGINX_PORT', str(client_port),
+        ).replace(
+            'FOG_VIEW_PORT', str(view_port),
+        ).replace(
+            'FOG_LEDGER_PORT', str(ledger_port),
+        ).replace(
+            'FOG_REPORT_PORT', str(report_port),
+        )
+        with open(self.conf_file, 'w') as f:
+            f.write(conf)
+
+    def start(self):
+        assert self.nginx_process is None
+        cmd = ' '.join([
+            'nginx',
+            f'-c {self.conf_file}',
+        ])
+
+        print(f'Starting fog nginx: {cmd}')
+
+        self.nginx_process = subprocess.Popen(cmd, shell=True)
+
+    def stop(self):
+        if self.nginx_process:
+            self.nginx_process.terminate()
+            self.nginx_process = None


### PR DESCRIPTION
### Motivation

Our k8/production networks exposes the assortment of fog servers we have (ledger, view, report) over a single URI endpoint (e.g. `fog://fog.test.mobilecoin.com`). Prior to this PR, the local fog network started by the fog conformance tests did not support doing this, making it incompatible with the mobile SDKs.

### In this PR
* Add `nginx` fronting the fog services when running a local fog network.
* Add a flag to the fog conformance test script for overriding the fog uri handed to the remote wallet service. By default, the script will use `insecure-fog://localhost:8200` (8200 is the new `nginx` port). This is good when everything is running on the same machine, but when the remote wallet is running on, for example, a mobile phone or emulator then it needs to know how to connect back to the local fog network. This parameter enables specifying that.
* Fixing a bunch of regressions on documentation/fog local network script. 

### Future Work
There are two more pending items in the ongoing work to make the fog conformance tests play nicely with the mobile SDKs:
* Move from root entropy to bip39 entropy.
* When the remote wallet concept was introduced, the way fog conformance tests is ran has changed such that it now requires manually starting the remote wallet service. This can be improved for cases when everything is running locally (such as CI, or local development that doesn't involve mobile SDKs). Simplifying test running is desirable, so I would like to follow up with a PR that enables the fog conformance test script to take care of starting the sample paykit remote wallet service.

