### PR TITLE
Fog conformance start remote wallet

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -365,7 +365,7 @@ commands:
             export LEDGER_ENCLAVE_PRIVKEY=$(pwd)/mobilecoin/Enclave_private.pem
             export VIEW_ENCLAVE_PRIVKEY=$(pwd)/mobilecoin/Enclave_private.pem
 
-            apt-get update && apt-get install -y python3-venv nginx
+            apt-get update && apt-get install -y python3-venv
             cd tools/fog-local-network
             python3 -m venv env
             . ./env/bin/activate

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@
 version: 2.1
 
 defaults:
-  builder-install: &builder-install gcr.io/mobilenode-211420/builder-install:1_15
+  builder-install: &builder-install gcr.io/mobilenode-211420/builder-install:1_17
   android-bindings-builder: &android-bindings-builder gcr.io/mobilenode-211420/android-bindings-builder:1_2
   default-xcode-version: &default-xcode-version "12.0.0"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -374,8 +374,6 @@ commands:
             ./build.sh
             cd ../..
 
-            cargo build --bin sample_paykit_remote_wallet
-            ./target/debug/sample_paykit_remote_wallet &
             python ./tools/fog-local-network/fog_conformance_tests.py
 
   run-tests:

--- a/tools/fog-local-network/README.md
+++ b/tools/fog-local-network/README.md
@@ -120,11 +120,10 @@ Usage
 1. Activate the virtualenv: `. ./env/bin/activate`
 1. Install requirements: `pip install --upgrade pip && pip install -r requirements.txt`
 1. Compile the protobuf files into a python module: `./build.sh`
-1. Start the fog conformance test script: `./tools/fog_conformance_test.py`
+1. Start the fog conformance test script: `./tools/fog-local-network/fog_conformance_test.py`
 
 You can build the servers and test in release mode instead:
-`cargo run --bin sample_paykit_remote_wallet --release`
-`./tools/fog_conformance_test.py  --release`
+`./tools/fog-local-netwotk/fog_conformance_test.py --release`
 
 If you have already built in mobilecoin and fog, you can skip the build step with `--skip-build`.
 

--- a/tools/fog-local-network/README.md
+++ b/tools/fog-local-network/README.md
@@ -120,7 +120,6 @@ Usage
 1. Activate the virtualenv: `. ./env/bin/activate`
 1. Install requirements: `pip install --upgrade pip && pip install -r requirements.txt`
 1. Compile the protobuf files into a python module: `./build.sh`
-1. Start the sample paykit remote wallet server: `cargo run --bin sample_paykit_remote_wallet`
 1. Start the fog conformance test script: `./tools/fog_conformance_test.py`
 
 You can build the servers and test in release mode instead:


### PR DESCRIPTION
### Motivation

We'd like to make test running as easy as possible. This PR removes the need to manually start the Rust-based sample-paykit-remote-wallet utility, making it so that running the fog conformance tests is slightly easier.

### In this PR
* Change the `fog_conformance_tests.py` script to support running the rust sample paykit remote wallet in the background.

