### PR TITLE
Future clippy

### DIFF
--- a/android-bindings/src/bindings.rs
+++ b/android-bindings/src/bindings.rs
@@ -1561,7 +1561,8 @@ pub unsafe extern "C" fn Java_com_mobilecoin_lib_ReportResponse_init_1jni(
         let chain = (0..env.get_array_length(chain)?)
             .map(|index| {
                 let obj = env.get_object_array_element(chain, index)?;
-                Ok(env.convert_byte_array(obj.into_inner())?) // FIXME: into_inner() sane here?
+                env.convert_byte_array(obj.into_inner()) // FIXME: into_inner()
+                                                         // sane here?
             })
             .collect::<Result<Vec<Vec<u8>>, jni::errors::Error>>()?;
         let signature = env.convert_byte_array(signature)?;
@@ -1632,7 +1633,7 @@ pub unsafe extern "C" fn Java_com_mobilecoin_lib_VerificationReport_init_1jni(
         let chain = (0..env.get_array_length(chain)?)
             .map(|index| {
                 let obj = env.get_object_array_element(chain, index)?;
-                Ok(env.convert_byte_array(obj.into_inner())?)
+                env.convert_byte_array(obj.into_inner())
             })
             .collect::<Result<Vec<Vec<u8>>, jni::errors::Error>>()?;
         let http_body: String = env.get_string(http_body)?.into();

--- a/android-bindings/src/error.rs
+++ b/android-bindings/src/error.rs
@@ -82,8 +82,8 @@ pub enum McError {
     /// Other: {0}
     Other(String),
 
-    /// JNI: {0}
-    JNI(String),
+    /// Jni: {0}
+    Jni(String),
 
     /// Bip39: {0}
     Bip39(Bip39Error),
@@ -208,7 +208,7 @@ impl From<EncodingsError> for McError {
 
 impl From<jni::errors::Error> for McError {
     fn from(src: jni::errors::Error) -> Self {
-        Self::JNI(src.to_string())
+        Self::Jni(src.to_string())
     }
 }
 

--- a/fog/api/src/lib.rs
+++ b/fog/api/src/lib.rs
@@ -48,14 +48,14 @@ impl EnclaveGrpcChannel for view_grpc::FogViewApiClient {
         msg: &attest::AuthMessage,
         creds: &BasicCredentials,
     ) -> Result<attest::AuthMessage, grpcio::Error> {
-        Ok(<Self>::auth_opt(self, msg, creds.call_option()?)?)
+        <Self>::auth_opt(self, msg, creds.call_option()?)
     }
     fn enclave_request(
         &mut self,
         msg: &attest::Message,
         creds: &BasicCredentials,
     ) -> Result<attest::Message, grpcio::Error> {
-        Ok(<Self>::query_opt(self, msg, creds.call_option()?)?)
+        <Self>::query_opt(self, msg, creds.call_option()?)
     }
 }
 
@@ -65,14 +65,14 @@ impl EnclaveGrpcChannel for ledger_grpc::FogKeyImageApiClient {
         msg: &attest::AuthMessage,
         creds: &BasicCredentials,
     ) -> Result<attest::AuthMessage, grpcio::Error> {
-        Ok(<Self>::auth_opt(self, msg, creds.call_option()?)?)
+        <Self>::auth_opt(self, msg, creds.call_option()?)
     }
     fn enclave_request(
         &mut self,
         msg: &attest::Message,
         creds: &BasicCredentials,
     ) -> Result<attest::Message, grpcio::Error> {
-        Ok(self.check_key_images_opt(msg, creds.call_option()?)?)
+        self.check_key_images_opt(msg, creds.call_option()?)
     }
 }
 
@@ -82,13 +82,13 @@ impl EnclaveGrpcChannel for ledger_grpc::FogMerkleProofApiClient {
         msg: &attest::AuthMessage,
         creds: &BasicCredentials,
     ) -> Result<attest::AuthMessage, grpcio::Error> {
-        Ok(<Self>::auth_opt(self, msg, creds.call_option()?)?)
+        <Self>::auth_opt(self, msg, creds.call_option()?)
     }
     fn enclave_request(
         &mut self,
         msg: &attest::Message,
         creds: &BasicCredentials,
     ) -> Result<attest::Message, grpcio::Error> {
-        Ok(self.get_outputs_opt(msg, creds.call_option()?)?)
+        self.get_outputs_opt(msg, creds.call_option()?)
     }
 }

--- a/fog/ingest/server/src/controller.rs
+++ b/fog/ingest/server/src/controller.rs
@@ -1037,8 +1037,7 @@ where
         };
         let report_id = self.config.fog_report_id.as_ref();
 
-        Ok(self
-            .recovery_db
+        self.recovery_db
             .set_report(ingress_public_key, report_id, &report_data)
             .map_err(|err| {
                 log::error!(
@@ -1050,7 +1049,7 @@ where
                 // ReportDB error to IngestServiceError but the caller won't do
                 // much but log this error eventually so...
                 Error::PublishReport
-            })?)
+            })
     }
 
     // Helper which writes out the state file. This should be done after processing

--- a/fog/ingest/server/src/ingest_service.rs
+++ b/fog/ingest/server/src/ingest_service.rs
@@ -119,18 +119,16 @@ where
 
     /// Logic of proto api
     pub fn retire_impl(&mut self, _: Empty, logger: &Logger) -> Result<IngestSummary, RpcStatus> {
-        Ok(self
-            .controller
+        self.controller
             .retire()
-            .map_err(|err| rpc_database_err(err, logger))?)
+            .map_err(|err| rpc_database_err(err, logger))
     }
 
     /// Logic of proto api
     pub fn unretire_impl(&mut self, _: Empty, logger: &Logger) -> Result<IngestSummary, RpcStatus> {
-        Ok(self
-            .controller
+        self.controller
             .unretire()
-            .map_err(|err| rpc_database_err(err, logger))?)
+            .map_err(|err| rpc_database_err(err, logger))
     }
 
     /// Report a lost ingress key

--- a/fog/kex_rng/src/versioned/buffered.rs
+++ b/fog/kex_rng/src/versioned/buffered.rs
@@ -134,17 +134,17 @@ where
 }
 
 // To Serialization Form
-impl<Core, KexAlgo> Into<StoredRng> for BufferedKexRng<Core, KexAlgo>
+impl<Core, KexAlgo> From<BufferedKexRng<Core, KexAlgo>> for StoredRng
 where
     Core: KexRngCore<KexAlgo>,
     KexAlgo: Kex,
 {
-    fn into(self) -> StoredRng {
+    fn from(src: BufferedKexRng<Core, KexAlgo>) -> StoredRng {
         StoredRng {
             version: Core::VERSION_ID,
-            secret: self.secret.as_slice().to_vec(),
-            buffer: self.buffer.as_slice().to_vec(),
-            counter: self.counter,
+            secret: src.secret.as_slice().to_vec(),
+            buffer: src.buffer.as_slice().to_vec(),
+            counter: src.counter,
         }
     }
 }

--- a/fog/kex_rng/src/versioned/macros.rs
+++ b/fog/kex_rng/src/versioned/macros.rs
@@ -63,10 +63,10 @@ macro_rules! impl_multiversion_kex_rng_enum {
         }
 
         // Forward to inner
-        impl Into<StoredRng> for $enum_name {
-            fn into(self) -> StoredRng {
-                match self {
-                    $(Self::$rng_name(inner) => inner.into(),)+
+        impl From<$enum_name> for StoredRng {
+            fn from(src: $enum_name) -> StoredRng {
+                match src {
+                    $($enum_name::$rng_name(inner) => inner.into(),)+
                 }
             }
         }

--- a/fog/load_testing/src/bin/ingest.rs
+++ b/fog/load_testing/src/bin/ingest.rs
@@ -29,7 +29,7 @@ use mc_util_uri::AdminUri;
 use mc_watcher::watcher_db::WatcherDB;
 use retry::{delay, retry, OperationResult};
 use std::{
-    path::PathBuf,
+    path::Path,
     str::FromStr,
     sync::Arc,
     time::{Duration, Instant},
@@ -113,13 +113,11 @@ impl core::fmt::Display for TestResult {
     }
 }
 
-fn load_test(
-    ingest_server_binary: &PathBuf,
-    test_params: TestParams,
-    logger: Logger,
-) -> TestResult {
-    let mut test_results = TestResult::default();
-    test_results.params = test_params.clone();
+fn load_test(ingest_server_binary: &Path, test_params: TestParams, logger: Logger) -> TestResult {
+    let mut test_results = TestResult {
+        params: test_params.clone(),
+        ..Default::default()
+    };
 
     {
         // First make grpcio env

--- a/fog/ocall_oram_storage/trusted/src/lib.rs
+++ b/fog/ocall_oram_storage/trusted/src/lib.rs
@@ -550,11 +550,8 @@ mod helpers {
 
 // This stuff must match edl file
 extern "C" {
-    #[no_mangle]
     fn allocate_oram_storage(count: u64, data_size: u64, meta_size: u64, id: *mut u64);
-    #[no_mangle]
     fn release_oram_storage(id: u64);
-    #[no_mangle]
     fn checkout_oram_storage(
         id: u64,
         idx: *const u64,
@@ -564,8 +561,6 @@ extern "C" {
         metabuf: *mut u64,
         metabuf_size: usize,
     );
-
-    #[no_mangle]
     fn checkin_oram_storage(
         id: u64,
         idx: *const u64,

--- a/fog/ocall_oram_storage/untrusted/src/lib.rs
+++ b/fog/ocall_oram_storage/untrusted/src/lib.rs
@@ -170,7 +170,7 @@ pub unsafe extern "C" fn allocate_oram_storage(
         data_size as usize,
         meta_size as usize,
     ));
-    let id: u64 = core::mem::transmute(Box::into_raw(result));
+    let id = Box::into_raw(result) as u64;
     #[cfg(debug_assertions)]
     debug_checks::add_id(id);
     *id_out = id;

--- a/fog/sql_recovery_db/src/error.rs
+++ b/fog/sql_recovery_db/src/error.rs
@@ -9,8 +9,8 @@ use r2d2::Error as R2d2Error;
 
 #[derive(Display, Debug)]
 pub enum Error {
-    /// ORM: {0}
-    ORM(DieselError),
+    /// Orm: {0}
+    Orm(DieselError),
 
     /// R2d2: {0}
     R2d2(R2d2Error),
@@ -50,7 +50,7 @@ impl Error {
     /// Policy decision, whether the call should be retried.
     pub fn should_retry(&self) -> bool {
         match self {
-            Self::ORM(DieselError::DatabaseError(_, info)) => {
+            Self::Orm(DieselError::DatabaseError(_, info)) => {
                 info.message() == "no connection to the server\n"
                     || info.message() == "terminating connection due to administrator command"
             }
@@ -61,7 +61,7 @@ impl Error {
 
 impl From<DieselError> for Error {
     fn from(src: DieselError) -> Self {
-        Self::ORM(src)
+        Self::Orm(src)
     }
 }
 

--- a/fog/sql_recovery_db/src/lib.rs
+++ b/fog/sql_recovery_db/src/lib.rs
@@ -136,8 +136,7 @@ impl SqlRecoveryDb {
 
         let rows = query.load::<(i64, Option<i64>, Option<i64>)>(conn)?;
 
-        Ok(rows
-            .iter()
+        rows.iter()
             .map(|row| match row {
                 (_, Some(start_index), Some(end_index)) => {
                     Ok(BlockRange::new(*start_index as u64, *end_index as u64))
@@ -147,7 +146,7 @@ impl SqlRecoveryDb {
                     "missing start or end block indices",
                 )),
             })
-            .collect::<Result<Vec<BlockRange>, Error>>()?)
+            .collect::<Result<Vec<BlockRange>, Error>>()
     }
 
     fn get_ingress_key_status_impl(
@@ -464,7 +463,7 @@ impl RecoveryDb for SqlRecoveryDb {
             // of an error This makes it a little easier for the caller to access this
             // information without making custom traits for interrogating generic
             // errors.
-            Err(Self::Error::ORM(diesel::result::Error::DatabaseError(
+            Err(Self::Error::Orm(diesel::result::Error::DatabaseError(
                 diesel::result::DatabaseErrorKind::UniqueViolation,
                 _,
             ))) => Ok(AddBlockDataStatus {
@@ -951,7 +950,7 @@ impl ReportDb for SqlRecoveryDb {
     ) -> Result<IngressPublicKeyStatus, Self::Error> {
         let conn = self.pool.get()?;
 
-        Ok(conn.build_transaction().read_write().run(
+        conn.build_transaction().read_write().run(
             || -> Result<IngressPublicKeyStatus, Self::Error> {
                 // First, try to update the pubkey_expiry value on this ingress key, only
                 // allowing it to increase, and only if it is not retired
@@ -1021,7 +1020,7 @@ impl ReportDb for SqlRecoveryDb {
                     .execute(&conn)?;
                 Ok(result)
             },
-        )?)
+        )
     }
 
     /// Remove report data associated with a given report id.

--- a/fog/sql_recovery_db/src/test_utils.rs
+++ b/fog/sql_recovery_db/src/test_utils.rs
@@ -21,6 +21,7 @@ impl SqlRecoveryDbTestContext {
             thread_rng()
                 .sample_iter(&Alphanumeric)
                 .take(10)
+                .map(char::from)
                 .collect::<String>()
                 .to_lowercase()
         );

--- a/fog/test_infra/src/lib.rs
+++ b/fog/test_infra/src/lib.rs
@@ -104,8 +104,11 @@ pub fn test_block<T: RngCore + CryptoRng, C: FogViewConnection>(
     // does not allow signatures for block 0.
     if block_index > 0 {
         for src_url in watcher.get_config_urls().unwrap().iter() {
-            let mut block = Block::default(); // Dummy block - we don't work with blocks in this test framework
-            block.index = block_index;
+            let block = Block {
+                // Dummy block - we don't work with blocks in this test framework
+                index: block_index,
+                ..Default::default()
+            };
             let mut block_signature =
                 BlockSignature::from_block_and_keypair(&block, &Ed25519Pair::from_random(rng))
                     .expect("Could not create block signature from keypair");

--- a/fog/view/connection/src/lib.rs
+++ b/fog/view/connection/src/lib.rs
@@ -52,14 +52,17 @@ impl FogViewConnection for FogViewGrpcClient {
             search_keys.len()
         );
 
-        let mut req: fog_types::view::QueryRequest = Default::default();
-        req.get_txos = search_keys;
+        let req = fog_types::view::QueryRequest {
+            get_txos: search_keys,
+        };
 
-        let mut req_aad: fog_types::view::QueryRequestAAD = Default::default();
-        req_aad.start_from_user_event_id = start_from_user_event_id;
-        req_aad.start_from_block_index = start_from_block_index;
+        let req_aad = fog_types::view::QueryRequestAAD {
+            start_from_user_event_id,
+            start_from_block_index,
+        };
+
         let aad_bytes = mc_util_serial::encode(&req_aad);
 
-        Ok(self.conn.encrypted_enclave_request(&req, &aad_bytes)?)
+        self.conn.encrypted_enclave_request(&req, &aad_bytes)
     }
 }

--- a/fog/view/enclave/impl/src/e_tx_out_store.rs
+++ b/fog/view/enclave/impl/src/e_tx_out_store.rs
@@ -92,19 +92,19 @@ impl<OSC: ORAMStorageCreator<StorageDataSize, StorageMetaSize>> ETxOutStore<OSC>
         ciphertext: &[u8],
     ) -> Result<(), AddRecordsError> {
         if search_key.len() != KeySize::USIZE {
-            Err(AddRecordsError::KeyWrongSize)?;
+            return Err(AddRecordsError::KeyWrongSize);
         }
         if ciphertext.len() > ValueSize::USIZE - 1 {
-            Err(AddRecordsError::ValueTooLarge)?;
+            return Err(AddRecordsError::ValueTooLarge);
         }
         if ciphertext.len() < ValueSize::USIZE.saturating_sub(256) {
-            Err(AddRecordsError::ValueWrongSize)?;
+            return Err(AddRecordsError::ValueWrongSize);
         }
 
         let mut key = A8Bytes::<KeySize>::default();
         let mut value = A8Bytes::<ValueSize>::default();
 
-        key.clone_from_slice(&search_key[..]);
+        key.clone_from_slice(search_key);
         value[0] = (ValueSize::USIZE - 1 - ciphertext.len()) as u8;
         let data_end = ValueSize::USIZE - value[0] as usize;
         (&mut value[1..data_end]).clone_from_slice(ciphertext);
@@ -148,7 +148,7 @@ impl<OSC: ORAMStorageCreator<StorageDataSize, StorageMetaSize>> ETxOutStore<OSC>
         }
 
         let mut key = A8Bytes::<KeySize>::default();
-        key.clone_from_slice(&search_key[..]);
+        key.clone_from_slice(search_key);
 
         let mut value = A8Bytes::<ValueSize>::default();
         value[0] = self.last_ciphertext_size_byte;

--- a/libmobilecoin/src/attest.rs
+++ b/libmobilecoin/src/attest.rs
@@ -470,7 +470,7 @@ impl<'a> TryFromFfi<FfiStr<'a>> for ResponderId {
 
     fn try_from_ffi(src: FfiStr<'a>) -> Result<Self, LibMcError> {
         let str = <&str>::try_from_ffi(src)?;
-        Ok(ResponderId::from_str(str)
-            .map_err(|err| LibMcError::InvalidInput(format!("Invalid responder id: {:?}", err)))?)
+        ResponderId::from_str(str)
+            .map_err(|err| LibMcError::InvalidInput(format!("Invalid responder id: {:?}", err)))
     }
 }

--- a/libmobilecoin/src/common/buffer.rs
+++ b/libmobilecoin/src/common/buffer.rs
@@ -202,8 +202,8 @@ impl<'a> FfiTryFrom<size_t> for ssize_t {
     type Error = LibMcError;
 
     fn ffi_try_from(src: size_t) -> Result<Self, LibMcError> {
-        Ok(ssize_t::try_from(src).map_err(|err| {
+        ssize_t::try_from(src).map_err(|err| {
             LibMcError::InvalidOutput(format!("Overflow converting to ssize_t: {:?}", err))
-        })?)
+        })
     }
 }

--- a/libmobilecoin/src/common/into_ffi.rs
+++ b/libmobilecoin/src/common/into_ffi.rs
@@ -169,7 +169,7 @@ where
 
     #[inline]
     fn try_from_ffi(src: Option<T>) -> Result<Self, Self::Error> {
-        Ok(src.map(U::try_from_ffi).transpose()?)
+        src.map(U::try_from_ffi).transpose()
     }
 }
 
@@ -181,7 +181,7 @@ where
 
     #[inline]
     fn try_from_ffi(src: FfiOptStr<'a>) -> Result<Self, Self::Error> {
-        Ok(src.as_option().map(U::try_from_ffi).transpose()?)
+        src.as_option().map(U::try_from_ffi).transpose()
     }
 }
 
@@ -193,7 +193,7 @@ where
 
     #[inline]
     fn try_from_ffi(src: FfiOptRefPtr<'a, T>) -> Result<Self, Self::Error> {
-        Ok(src.as_ref().map(U::try_from_ffi).transpose()?)
+        src.as_ref().map(U::try_from_ffi).transpose()
     }
 }
 

--- a/libmobilecoin/src/common/rng.rs
+++ b/libmobilecoin/src/common/rng.rs
@@ -28,9 +28,9 @@ impl<'a> FfiTryFrom<u64> for i64 {
     type Error = LibMcError;
 
     fn ffi_try_from(src: u64) -> Result<Self, LibMcError> {
-        Ok(i64::try_from(src).map_err(|err| {
+        i64::try_from(src).map_err(|err| {
             LibMcError::InvalidOutput(format!("Overflow converting to i64: {:?}", err))
-        })?)
+        })
     }
 }
 

--- a/libmobilecoin/src/common/string.rs
+++ b/libmobilecoin/src/common/string.rs
@@ -34,9 +34,8 @@ impl<'a> TryFromFfi<FfiStr<'a>> for &'a str {
     type Error = LibMcError;
 
     fn try_from_ffi(src: FfiStr<'a>) -> Result<Self, LibMcError> {
-        Ok(src
-            .as_str()
-            .map_err(|err| LibMcError::InvalidInput(format!("Invalid UTF-8: {:?}", err)))?)
+        src.as_str()
+            .map_err(|err| LibMcError::InvalidInput(format!("Invalid UTF-8: {:?}", err)))
     }
 }
 
@@ -54,7 +53,7 @@ impl<'a> FfiTryFrom<&str> for FfiOwnedStr {
 
     #[inline]
     fn ffi_try_from(src: &str) -> Result<Self, LibMcError> {
-        Ok(FfiOwnedStr::ffi_try_from(src.to_owned())?)
+        FfiOwnedStr::ffi_try_from(src.to_owned())
     }
 }
 
@@ -73,7 +72,7 @@ impl<'a> FfiTryFrom<Option<&str>> for FfiOptOwnedStr {
 
     #[inline]
     fn ffi_try_from(src: Option<&str>) -> Result<Self, LibMcError> {
-        Ok(FfiOptOwnedStr::ffi_try_from(src.map(ToOwned::to_owned))?)
+        FfiOptOwnedStr::ffi_try_from(src.map(ToOwned::to_owned))
     }
 }
 

--- a/libmobilecoin/src/crypto.rs
+++ b/libmobilecoin/src/crypto.rs
@@ -16,8 +16,7 @@ impl<'a> TryFromFfi<&McBuffer<'a>> for RistrettoPublic {
 
     fn try_from_ffi(src: &McBuffer<'a>) -> Result<Self, LibMcError> {
         let src = <&[u8; 32]>::try_from_ffi(src)?;
-        Ok(RistrettoPublic::try_from(src)
-            .map_err(|err| LibMcError::InvalidInput(format!("{:?}", err)))?)
+        RistrettoPublic::try_from(src).map_err(|err| LibMcError::InvalidInput(format!("{:?}", err)))
     }
 }
 
@@ -26,8 +25,8 @@ impl<'a> TryFromFfi<&McBuffer<'a>> for RistrettoPrivate {
 
     fn try_from_ffi(src: &McBuffer<'a>) -> Result<Self, LibMcError> {
         let src = <&[u8; 32]>::try_from_ffi(src)?;
-        Ok(RistrettoPrivate::try_from(src)
-            .map_err(|err| LibMcError::InvalidInput(format!("{:?}", err)))?)
+        RistrettoPrivate::try_from(src)
+            .map_err(|err| LibMcError::InvalidInput(format!("{:?}", err)))
     }
 }
 
@@ -79,8 +78,7 @@ impl<'a> TryFromFfi<&McBuffer<'a>> for Signature {
 
     fn try_from_ffi(src: &McBuffer<'a>) -> Result<Self, LibMcError> {
         let src = src.as_slice_of_len(SIGNATURE_LENGTH)?;
-        Ok(Signature::from_bytes(src)
-            .map_err(|err| LibMcError::InvalidInput(format!("{:?}", err)))?)
+        Signature::from_bytes(src).map_err(|err| LibMcError::InvalidInput(format!("{:?}", err)))
     }
 }
 

--- a/libmobilecoin/src/encodings.rs
+++ b/libmobilecoin/src/encodings.rs
@@ -12,8 +12,7 @@ impl<'a> TryFromFfi<&McBuffer<'a>> for PrintableWrapper {
     type Error = LibMcError;
 
     fn try_from_ffi(src: &McBuffer<'a>) -> Result<Self, Self::Error> {
-        Ok(Self::parse_from_bytes(&src)
-            .map_err(|err| LibMcError::InvalidInput(format!("{:?}", err)))?)
+        Self::parse_from_bytes(&src).map_err(|err| LibMcError::InvalidInput(format!("{:?}", err)))
     }
 }
 


### PR DESCRIPTION
### Motivation

In preparation for a Rust version upgrade I ran into a bunch of small things future clippy will complain about, so here are fixes for them.

### In this PR
* `impl Into` -> `impl From`
* `ORM` -> `Orm`
* Getting rid of some redundant usages of the question-mark operator
* Getting rid of some unnecessary slices
* Initializing structs in a way that pleases clippy
* Removing an unnecessary `transmute` call
* Remove unnecessary `#[no_mangle]` attributes

