### PR TITLE
Fix symbol stripping when compiling LibMobileCoin

### DIFF
--- a/libmobilecoin/Makefile
+++ b/libmobilecoin/Makefile
@@ -79,7 +79,7 @@ $(ARCHS_IOS):
 
 	@# Create list of libmobilecoin symbols.
 	cd $(CARGO_TARGET_DIR)/$@/$(BUILD_CONFIG_FOLDER) && \
-		nm -jgU extracted/mobilecoin*.mobilecoin.*.o -s __TEXT __text 2>/dev/null \
+		nm -jgU extracted/mobilecoin*.mobilecoin.*.o -s __TEXT __text \
 			| grep '\<_mc_' \
 			> exported-symbols.def
 

--- a/libmobilecoin/Makefile
+++ b/libmobilecoin/Makefile
@@ -48,6 +48,8 @@ all: setup ios
 .PHONY: setup
 setup:
 	rustup target add $(ARCHS_IOS)
+	rustup component add llvm-tools-preview
+	rustup run --install stable cargo install cargo-binutils
 
 .PHONY: ios
 ios: out/ios/$(IOS_LIB)
@@ -79,7 +81,7 @@ $(ARCHS_IOS):
 
 	@# Create list of libmobilecoin symbols.
 	cd $(CARGO_TARGET_DIR)/$@/$(BUILD_CONFIG_FOLDER) && \
-		nm -jgU extracted/mobilecoin*.mobilecoin.*.o -s __TEXT __text \
+		rust-nm -jgU extracted/mobilecoin*.mobilecoin.*.o -s __TEXT __text \
 			| grep '\<_mc_' \
 			> exported-symbols.def
 


### PR DESCRIPTION
### Motivation

This PR fixes an error when compiling LibMobileCoin using upgraded Rust versions.

### In this PR
* Remove `2>/dev/null` so that errors thrown by `nm` aren't hidden.
* Use `llvm-tools-preview` instead of Xcode for `nm`.

