### PR TITLE
Revert "fog omits compressed commitment from TxOutRecord (#71)"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1764,7 +1764,6 @@ name = "fog-types"
 version = "1.0.0"
 dependencies = [
  "blake2",
- "crc",
  "displaydoc",
  "fog-kex-rng",
  "mc-crypto-keys",

--- a/fog/api/proto/view.proto
+++ b/fog/api/proto/view.proto
@@ -204,6 +204,20 @@ enum TxOutSearchResultCode {
     RateLimited = 5;
 }
 
+
+/// A Redacted Fog Transaction Output.
+/// This is the same as a normal TxOut, except that the fog hint is removed after processing, to save storage.
+message FogTxOut {
+    /// Amount.
+    external.Amount amount = 1;
+
+    /// Public key.
+    external.CompressedRistretto target_key = 2;
+
+    /// Public key.
+    external.CompressedRistretto public_key = 3;
+}
+
 /// The schema for the decrypted TxOutSearchResult ciphertext
 /// This is the information that the Ingest enclave produces for the user about their TxOut
 ///
@@ -217,8 +231,6 @@ enum TxOutSearchResultCode {
 /// and that's the version of the TxOut that you should use when building a transaction.
 message TxOutRecord {
     /// The (compressed ristretto) bytes of commitment associated to amount field in the TxOut that was recovered
-    ///
-    /// Note: This field is omitted in recent versions, because it can be reconstructed by the recipient instead.
     bytes tx_out_amount_commitment_data = 1;
     /// The masked value associated to amount field in the TxOut that was recovered
     fixed64 tx_out_amount_masked_value = 2;
@@ -255,10 +267,4 @@ message TxOutRecord {
     ///
     /// Represented as seconds of UTC time since Unix epoch 1970-01-01T00:00:00Z.
     fixed64 timestamp = 7;
-    /// The crc32 of the commitment data bytes.
-    /// This is a 4-byte IEEE crc32 of the bytes of the tx_out_amount_commitment_data bytes, which is present if
-    /// the full tx_out_amount_commitment_data is omitted.
-    /// The client can recompute the tx_out_amount_commitment from the other data that we include.
-    /// They can confirm correct recomputation by checking this crc value.
-    fixed32 tx_out_amount_commitment_data_crc32 = 8;
 }

--- a/fog/api/tests/fog_types.rs
+++ b/fog/api/tests/fog_types.rs
@@ -198,14 +198,35 @@ fn tx_out_record_round_trip() {
 
     run_with_several_seeds(|mut rng| {
         let fog_txout = fog_types::view::FogTxOut::from(&TxOut::sample(&mut rng));
-        let meta = fog_types::view::FogTxOutMetadata {
-            global_index: rng.next_u64(),
+
+        let commitment_bytes: &[u8; 32] = fog_txout.amount.commitment.as_ref();
+        let test_val = fog_types::view::TxOutRecord {
+            tx_out_amount_commitment_data: commitment_bytes.to_vec(),
+            tx_out_amount_masked_value: fog_txout.amount.masked_value,
+            tx_out_target_key_data: fog_txout.target_key.as_bytes().to_vec(),
+            tx_out_public_key_data: fog_txout.public_key.as_bytes().to_vec(),
+            tx_out_global_index: rng.next_u64(),
             block_index: rng.next_u64(),
-            timestamp: rng.next_u64(),
+            timestamp: 9,
         };
-        let test_val = fog_types::view::TxOutRecord::new(fog_txout, meta);
 
         round_trip_message::<fog_types::view::TxOutRecord, fog_api::view::TxOutRecord>(&test_val);
+    });
+}
+
+/// Test that many random instances of prosty FogTxOut round trip with protobufy
+/// FogTxOut
+#[test]
+fn fog_tx_out_round_trip() {
+    {
+        let test_val: fog_types::view::FogTxOut = Default::default();
+        round_trip_message::<fog_types::view::FogTxOut, fog_api::view::FogTxOut>(&test_val);
+    }
+
+    run_with_several_seeds(|mut rng| {
+        let test_val = fog_types::view::FogTxOut::from(&TxOut::sample(&mut rng));
+
+        round_trip_message::<fog_types::view::FogTxOut, fog_api::view::FogTxOut>(&test_val);
     });
 }
 

--- a/fog/fog_types/Cargo.toml
+++ b/fog/fog_types/Cargo.toml
@@ -12,7 +12,6 @@ mc-watcher-api = { path = "../../mobilecoin/watcher/api" }
 
 fog-kex-rng = { path = "../kex_rng" }
 
-crc = { version = "1.8.1", default-features = false }
 displaydoc = { version = "0.2", default-features = false }
 prost = { version = "0.6.1", default-features = false, features = ["prost-derive"] }
 serde = { version = "1.0", default-features = false, features = ["derive"] }

--- a/fog/fog_types/src/view.rs
+++ b/fog/fog_types/src/view.rs
@@ -2,14 +2,13 @@
 
 use crate::common::BlockRange;
 use alloc::vec::Vec;
-use core::convert::TryFrom;
-use crc::crc32;
+use core::convert::{TryFrom, TryInto};
 use displaydoc::Display;
-use mc_crypto_keys::{CompressedRistrettoPublic, KeyError, RistrettoPrivate, RistrettoPublic};
+use mc_crypto_keys::{CompressedRistrettoPublic, KeyError};
 use mc_transaction_core::{
     encrypted_fog_hint::{EncryptedFogHint, ENCRYPTED_FOG_HINT_LEN},
     tx::TxOut,
-    Amount, AmountError,
+    Amount, CompressedCommitment,
 };
 use prost::Message;
 use serde::{Deserialize, Serialize};
@@ -162,10 +161,8 @@ pub struct TxOutSearchResult {
 #[derive(Clone, Eq, Hash, PartialEq, Message)]
 pub struct TxOutRecord {
     /// The (compressed ristretto) bytes of commitment associated to amount
-    /// field in the TxOut that was recovered.
-    /// Note: These bytes are omitted in latest versions, and only the IEEE
-    /// crc32 checksum of these bytes is stored.
-    #[prost(bytes, tag = "1")]
+    /// field in the TxOut that was recovered
+    #[prost(bytes, required, tag = "1")]
     pub tx_out_amount_commitment_data: Vec<u8>,
     /// The masked value associated to amount field in the TxOut that was
     /// recovered
@@ -193,178 +190,69 @@ pub struct TxOutRecord {
     /// epoch 1970-01-01T00:00:00Z.
     #[prost(fixed64, tag = "7")]
     pub timestamp: u64,
-
-    /// The IEEE crc32 bytes of the (omitted) amount commitment data.
-    /// This is here so that the client can check that they derived commitment
-    /// data successfully.
-    #[prost(fixed32, tag = "8")]
-    pub tx_out_amount_commitment_data_crc32: u32,
 }
 
 impl TxOutRecord {
-    /// Construct a TxOutRecord from FogTxOut and metadata, in the new way
-    /// (omitting compressed commitment)
-    ///
-    /// Arguments:
-    /// * FogTxOut: The representation of a TxOut preserved in the TxOutRecord
-    /// * FogTxOutMetadata: The additional data not from the TxOut itself that
-    ///   we preserve in TxOutRecord
-    pub fn new(fog_tx_out: FogTxOut, meta: FogTxOutMetadata) -> Self {
-        Self {
-            tx_out_amount_commitment_data: Default::default(),
-            tx_out_amount_commitment_data_crc32: fog_tx_out.amount_commitment_data_crc32,
-            tx_out_amount_masked_value: fog_tx_out.amount_masked_value,
-            tx_out_target_key_data: fog_tx_out.target_key.as_bytes().to_vec(),
-            tx_out_public_key_data: fog_tx_out.public_key.as_bytes().to_vec(),
-            tx_out_global_index: meta.global_index,
-            block_index: meta.block_index,
-            timestamp: meta.timestamp,
-        }
-    }
-
-    /// Extract a FogTxOut object from the (flattened) TxOutRecord object
-    /// Note that this discards some metadata (timestamp, block_index,
-    /// global_index).
+    /// Helper to extract a FogTxOut object from the (flattened) TxOutRecord
+    /// object
     pub fn get_fog_tx_out(&self) -> Result<FogTxOut, KeyError> {
-        // There are two cases: TxOutRecord with full amount data, and TxOutRecord with
-        // only commitment data crc32 and masked value.
-        if self.tx_out_amount_commitment_data.is_empty() {
-            return Ok(FogTxOut {
-                target_key: CompressedRistrettoPublic::try_from(&self.tx_out_target_key_data[..])?,
-                public_key: CompressedRistrettoPublic::try_from(&self.tx_out_public_key_data[..])?,
-                amount_masked_value: self.tx_out_amount_masked_value,
-                amount_commitment_data_crc32: self.tx_out_amount_commitment_data_crc32,
-            });
-        }
-
-        // If we are provided with a commitment, then we should compute crc32 of it and
-        // discard those bytes, in order to unify early to one code path.
+        // CompressedCommitment does not implement TryFrom, so we have to do the logic
+        // here
         if self.tx_out_amount_commitment_data.len() != 32 {
             return Err(KeyError::LengthMismatch(
                 32,
                 self.tx_out_amount_commitment_data.len(),
             ));
         }
+        let commitment_bytes: &[u8; 32] =
+            &self.tx_out_amount_commitment_data[..].try_into().unwrap();
         Ok(FogTxOut {
+            amount: Amount {
+                commitment: CompressedCommitment::from(commitment_bytes),
+                masked_value: self.tx_out_amount_masked_value,
+            },
             target_key: CompressedRistrettoPublic::try_from(&self.tx_out_target_key_data[..])?,
             public_key: CompressedRistrettoPublic::try_from(&self.tx_out_public_key_data[..])?,
-            amount_masked_value: self.tx_out_amount_masked_value,
-            amount_commitment_data_crc32: crc32::checksum_ieee(&self.tx_out_amount_commitment_data),
         })
     }
 }
 
-// FogTxOut is a redacted version of the TxOut, removing the fog hint, and with
-// reduced data about Amount. The hint is only used during ingest, so we don't
-// need to persist it.
-#[derive(Clone, Eq, Hash, PartialEq, Debug, Default)]
+// FogTxOut is a redacted version of the TxOut, removing the fog hint.
+// The hint is only used during ingest, so we don't need to persist it.
+#[derive(Clone, Eq, Hash, PartialEq, Message)]
 pub struct FogTxOut {
+    /// The amount being sent.
+    #[prost(message, required, tag = "1")]
+    pub amount: Amount,
+
     /// The one-time public address of this output.
+    #[prost(message, required, tag = "2")]
     pub target_key: CompressedRistrettoPublic,
 
     /// The per output tx public key
+    #[prost(message, required, tag = "3")]
     pub public_key: CompressedRistrettoPublic,
-
-    /// The tx out masked amount
-    pub amount_masked_value: u64,
-
-    /// The crc32 of the tx out amount commitment bytes
-    pub amount_commitment_data_crc32: u32,
 }
 
-// Convert a TxOut to a FogTxOut in the efficient way (omitting compressed
-// commitment)
 impl core::convert::From<&TxOut> for FogTxOut {
     #[inline]
     fn from(src: &TxOut) -> Self {
         Self {
+            amount: src.amount.clone(),
             target_key: src.target_key,
             public_key: src.public_key,
-            amount_masked_value: src.amount.masked_value,
-            amount_commitment_data_crc32: crc32::checksum_ieee(
-                src.amount.commitment.point.as_bytes(),
-            ),
         }
     }
 }
 
-impl FogTxOut {
-    /// Try to recover a TxOut from a FogTxOut and the user's private view key.
-    ///
-    /// * The amount commitment data is reconstructed, then we check if the
-    ///   reconstructed data matches the crc32 provided.
-    /// * The encrypted fog hint data is zeroed since it is not reconstructible
-    ///   and isn't needed by the client.
-    ///
-    /// Arguments:
-    /// * view_key: the private view key of the recipient of this TxOut
-    ///
-    /// Returns:
-    /// * TxOut,
-    /// Or
-    /// * An error if recovery failed
-    pub fn try_recover_tx_out(&self, view_key: &RistrettoPrivate) -> Result<TxOut, FogTxOutError> {
-        // Reconstruct compressed commitment based on our view key.
-        // The first step is reconstructing the TxOut shared secret
-        let public_key = RistrettoPublic::try_from(&self.public_key)?;
-        let tx_out_shared_secret =
-            mc_transaction_core::get_tx_out_shared_secret(view_key, &public_key);
-
-        // The next step is unblinding the amount value
-        let value =
-            self.amount_masked_value ^ mc_transaction_core::get_value_mask(&tx_out_shared_secret);
-
-        // Now we can rebuild the Amount object from the value and shared secret
-        let amount = Amount::new(value, &tx_out_shared_secret)?;
-
-        // Check that the crc32 of amount compressed commitment matches
-        if self.amount_commitment_data_crc32
-            != crc32::checksum_ieee(amount.commitment.point.as_bytes())
-        {
-            return Err(FogTxOutError::ChecksumMismatch);
-        }
-
-        Ok(TxOut {
-            amount,
-            target_key: self.target_key,
-            public_key: self.public_key,
+impl core::convert::From<&FogTxOut> for TxOut {
+    #[inline]
+    fn from(src: &FogTxOut) -> Self {
+        Self {
+            amount: src.amount.clone(),
+            target_key: src.target_key,
+            public_key: src.public_key,
             e_fog_hint: EncryptedFogHint::from(&[0u8; ENCRYPTED_FOG_HINT_LEN]),
-        })
+        }
     }
-}
-
-/// An error that occurs when trying to convert a FogTxOut to a TxOut
-#[derive(Display, Debug)]
-pub enum FogTxOutError {
-    /// CompressedCommitment crc32 mismatch
-    ChecksumMismatch,
-    /// An invalid amount: {0}
-    Amount(AmountError),
-    /// An invalid key: {0}
-    Key(KeyError),
-}
-
-impl From<AmountError> for FogTxOutError {
-    fn from(src: AmountError) -> Self {
-        Self::Amount(src)
-    }
-}
-
-impl From<KeyError> for FogTxOutError {
-    fn from(src: KeyError) -> Self {
-        Self::Key(src)
-    }
-}
-
-/// A collection of metadata about a TxOut that fog preserves in the TxOutRecord
-#[derive(Clone, Debug, Default, Eq, Hash, PartialEq)]
-pub struct FogTxOutMetadata {
-    /// The global index of this TxOut in the set of all TxOut's in the
-    /// blockchain
-    pub global_index: u64,
-    /// The index of the block in which this TxOut appeared
-    pub block_index: u64,
-    /// The timestamp of the block in which this TxOut appeared, in seconds
-    /// since the Unix epoch.
-    pub timestamp: u64,
 }

--- a/fog/ingest/enclave/impl/src/lib.rs
+++ b/fog/ingest/enclave/impl/src/lib.rs
@@ -24,10 +24,7 @@ use fog_ingest_enclave_api::{
 };
 use fog_kex_rng::KexRngPubkey;
 use fog_recovery_db_iface::ETxOutRecord;
-use fog_types::{
-    ingest::TxsForIngest,
-    view::{FogTxOut, FogTxOutMetadata, TxOutRecord},
-};
+use fog_types::{ingest::TxsForIngest, view::TxOutRecord};
 use mc_attest_core::{
     IasNonce, IntelSealed, Quote, QuoteNonce, Report, TargetInfo, VerificationReport,
 };
@@ -142,15 +139,17 @@ impl<OSC: ORAMStorageCreator<StorageDataSize, StorageMetaSize>> SgxIngestEnclave
                 }
 
                 // Create a TxOutRecord, flattening the Txo data and getting extra data like
-                // global index, block index, timestamp.
-                let fog_tx_out = FogTxOut::from(txo);
-                let meta = FogTxOutMetadata {
-                    global_index: chunk.global_txo_index + index as u64,
+                // global index, block index, timestamp
+                let commitment_bytes: &[u8; 32] = txo.amount.commitment.as_ref();
+                let txo_record = TxOutRecord {
+                    tx_out_amount_commitment_data: commitment_bytes.to_vec(),
+                    tx_out_amount_masked_value: txo.amount.masked_value,
+                    tx_out_target_key_data: txo.target_key.as_bytes().to_vec(),
+                    tx_out_public_key_data: txo.public_key.as_bytes().to_vec(),
+                    tx_out_global_index: chunk.global_txo_index + index as u64,
                     block_index: chunk.block_index,
                     timestamp: chunk.timestamp,
                 };
-                let txo_record = TxOutRecord::new(fog_tx_out, meta);
-
                 // Get the view-kew-encrypted payload for this TX
                 let plaintext = mc_util_serial::encode(&txo_record);
 

--- a/fog/ingest/enclave/impl/tests/tx_processing.rs
+++ b/fog/ingest/enclave/impl/tests/tx_processing.rs
@@ -82,7 +82,7 @@ fn test_ingest_enclave(logger: Logger) {
         assert_eq!(tx_rows.len(), 10);
 
         // Check that the tx row ciphertexts have the right size
-        const EXPECTED_PAYLOAD_SIZE: usize = 159; // The observed tx_row.payload size
+        const EXPECTED_PAYLOAD_SIZE: usize = 188; // The observed tx_row.payload size
         for tx_row in tx_rows.iter() {
             assert_eq!(
                 tx_row.payload.len(), EXPECTED_PAYLOAD_SIZE,

--- a/fog/ingest/enclave/trusted/Cargo.lock
+++ b/fog/ingest/enclave/trusted/Cargo.lock
@@ -228,12 +228,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
-name = "build_const"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ae4235e6dac0694637c763029ecea1a2ec9e4e06ec2729bd21ba4d9c863eb7"
-
-[[package]]
 name = "bulletproofs"
 version = "2.0.0"
 source = "git+https://github.com/eranrund/bulletproofs?rev=8a7c9cdd1efafa3ad68cd65676302f925de68373#8a7c9cdd1efafa3ad68cd65676302f925de68373"
@@ -354,15 +348,6 @@ dependencies = [
 name = "cpuid-bool"
 version = "0.1.2"
 source = "git+https://github.com/eranrund/RustCrypto-utils?rev=74f8e04e9d18d93fc6d05c72756c236dc88daa19#74f8e04e9d18d93fc6d05c72756c236dc88daa19"
-
-[[package]]
-name = "crc"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d663548de7f5cca343f1e0a48d14dcfb0e9eb4e079ec58883b7251539fa10aeb"
-dependencies = [
- "build_const",
-]
 
 [[package]]
 name = "crypto-mac"
@@ -592,7 +577,6 @@ name = "fog-types"
 version = "1.0.0"
 dependencies = [
  "blake2",
- "crc",
  "displaydoc",
  "fog-kex-rng",
  "mc-crypto-keys",

--- a/fog/ledger/enclave/trusted/Cargo.lock
+++ b/fog/ledger/enclave/trusted/Cargo.lock
@@ -186,12 +186,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
-name = "build_const"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ae4235e6dac0694637c763029ecea1a2ec9e4e06ec2729bd21ba4d9c863eb7"
-
-[[package]]
 name = "bulletproofs"
 version = "2.0.0"
 source = "git+https://github.com/eranrund/bulletproofs?rev=8a7c9cdd1efafa3ad68cd65676302f925de68373#8a7c9cdd1efafa3ad68cd65676302f925de68373"
@@ -312,15 +306,6 @@ dependencies = [
 name = "cpuid-bool"
 version = "0.1.2"
 source = "git+https://github.com/eranrund/RustCrypto-utils?rev=74f8e04e9d18d93fc6d05c72756c236dc88daa19#74f8e04e9d18d93fc6d05c72756c236dc88daa19"
-
-[[package]]
-name = "crc"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d663548de7f5cca343f1e0a48d14dcfb0e9eb4e079ec58883b7251539fa10aeb"
-dependencies = [
- "build_const",
-]
 
 [[package]]
 name = "crypto-mac"
@@ -491,7 +476,6 @@ name = "fog-types"
 version = "1.0.0"
 dependencies = [
  "blake2",
- "crc",
  "displaydoc",
  "fog-kex-rng",
  "mc-crypto-keys",

--- a/fog/sample-paykit/src/cached_tx_data/mod.rs
+++ b/fog/sample-paykit/src/cached_tx_data/mod.rs
@@ -582,10 +582,7 @@ impl OwnedTxOut {
     // so we need to backport that into the rust sample paykit.
     pub fn new(rec: TxOutRecord, account_key: &AccountKey) -> StdResult<Self, TxOutMatchingError> {
         // Reconstitute FogTxOut from the "flattened" data in TxOutRecord
-        let fog_tx_out = rec.get_fog_tx_out()?;
-
-        // Reconstute TxOut from FogTxOut and our view private key
-        let tx_out = fog_tx_out.try_recover_tx_out(&account_key.view_private_key())?;
+        let tx_out = rec.get_fog_tx_out()?;
 
         // This is view key scanning part, getting the value fails if view-key scanning
         // fails
@@ -609,7 +606,7 @@ impl OwnedTxOut {
         Ok(Self {
             global_index: rec.tx_out_global_index,
             block_index: rec.block_index,
-            tx_out,
+            tx_out: TxOut::from(&tx_out),
             key_image,
             value,
             status,

--- a/fog/sample-paykit/src/client.rs
+++ b/fog/sample-paykit/src/client.rs
@@ -623,7 +623,7 @@ fn build_transaction_helper<T: RngCore + CryptoRng, FPR: FogPubkeyResolver>(
 mod test_build_transaction_helper {
     use super::*;
     use core::result::Result as StdResult;
-    use fog_types::view::{FogTxOut, FogTxOutMetadata, TxOutRecord};
+    use fog_types::view::TxOutRecord;
     use mc_account_keys::{AccountKey, PublicAddress};
     use mc_common::logger::{test_with_logger, Logger};
     use mc_fog_report_validation::{FogPubkeyError, FullyValidatedFogPubkey};
@@ -671,9 +671,17 @@ mod test_build_transaction_helper {
             let cached_inputs: Vec<(OwnedTxOut, TxOutMembershipProof)> = outputs
                 .into_iter()
                 .map(|tx_out| {
-                    let fog_tx_out = FogTxOut::from(&tx_out);
-                    let meta = FogTxOutMetadata::default();
-                    let txo_record = TxOutRecord::new(fog_tx_out, meta);
+                    let commitment_bytes: &[u8; 32] = tx_out.amount.commitment.as_ref();
+
+                    let txo_record = TxOutRecord {
+                        tx_out_amount_commitment_data: commitment_bytes.to_vec(),
+                        tx_out_amount_masked_value: tx_out.amount.masked_value,
+                        tx_out_target_key_data: tx_out.target_key.as_bytes().to_vec(),
+                        tx_out_public_key_data: tx_out.public_key.as_bytes().to_vec(),
+                        block_index: 0,
+                        tx_out_global_index: 0,
+                        timestamp: Default::default(),
+                    };
 
                     let owned_tx_out = OwnedTxOut::new(txo_record, &sender_account_key).unwrap();
 

--- a/fog/sample-paykit/src/error.rs
+++ b/fog/sample-paykit/src/error.rs
@@ -5,7 +5,6 @@
 use displaydoc::Display;
 use fog_enclave_connection::Error as EnclaveConnectionError;
 use fog_ledger_connection::{Error as LedgerConnectionError, KeyImageQueryError};
-use fog_types::view::FogTxOutError;
 use fog_view_protocol::TxOutPollingError;
 use mc_connection::Error as ConnectionError;
 use mc_consensus_api::ConversionError;
@@ -29,9 +28,6 @@ pub enum TxOutMatchingError {
 
     /// Error parsing key: {0}
     Key(KeyError),
-
-    /// Error decompressing FogTxOut: {0}
-    FogTxOut(FogTxOutError),
 }
 
 impl From<AmountError> for TxOutMatchingError {
@@ -43,12 +39,6 @@ impl From<AmountError> for TxOutMatchingError {
 impl From<KeyError> for TxOutMatchingError {
     fn from(src: KeyError) -> Self {
         Self::Key(src)
-    }
-}
-
-impl From<FogTxOutError> for TxOutMatchingError {
-    fn from(src: FogTxOutError) -> Self {
-        Self::FogTxOut(src)
     }
 }
 

--- a/fog/test_infra/src/mock_users.rs
+++ b/fog/test_infra/src/mock_users.rs
@@ -4,10 +4,7 @@
 //! node, and then exercise the view node to try to find them.
 //! This is basically mocking both the consensus output and the SDK
 
-use fog_types::{
-    view::{FogTxOut, FogTxOutMetadata, TxOutRecord},
-    BlockCount,
-};
+use fog_types::{view::TxOutRecord, BlockCount};
 use fog_view_protocol::{FogViewConnection, UserPrivate, UserRngSet};
 use mc_common::logger::global_log;
 use mc_crypto_keys::RistrettoPublic;
@@ -75,15 +72,17 @@ pub fn test_block_to_inputs_and_expected_outputs(
             .entry(upriv.clone())
             .or_insert_with(HashSet::default);
 
-        let fog_tx_out = FogTxOut::from(txo);
-        let meta = FogTxOutMetadata {
-            global_index: global_tx_out_index as u64,
+        let commitment_bytes: &[u8; 32] = txo.amount.commitment.as_ref();
+
+        user_result_set.insert(TxOutRecord {
+            tx_out_amount_commitment_data: commitment_bytes.to_vec(),
+            tx_out_amount_masked_value: txo.amount.masked_value,
+            tx_out_target_key_data: txo.target_key.as_bytes().to_vec(),
+            tx_out_public_key_data: txo.public_key.as_bytes().to_vec(),
+            tx_out_global_index: global_tx_out_index as u64,
             block_index,
             timestamp,
-        };
-        let tx_out_record = TxOutRecord::new(fog_tx_out, meta);
-
-        user_result_set.insert(tx_out_record);
+        });
         global_tx_out_index += 1;
     }
 

--- a/fog/view/enclave/trusted/Cargo.lock
+++ b/fog/view/enclave/trusted/Cargo.lock
@@ -229,12 +229,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
-name = "build_const"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ae4235e6dac0694637c763029ecea1a2ec9e4e06ec2729bd21ba4d9c863eb7"
-
-[[package]]
 name = "bulletproofs"
 version = "2.0.0"
 source = "git+https://github.com/eranrund/bulletproofs?rev=8a7c9cdd1efafa3ad68cd65676302f925de68373#8a7c9cdd1efafa3ad68cd65676302f925de68373"
@@ -355,15 +349,6 @@ dependencies = [
 name = "cpuid-bool"
 version = "0.1.2"
 source = "git+https://github.com/eranrund/RustCrypto-utils?rev=74f8e04e9d18d93fc6d05c72756c236dc88daa19#74f8e04e9d18d93fc6d05c72756c236dc88daa19"
-
-[[package]]
-name = "crc"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d663548de7f5cca343f1e0a48d14dcfb0e9eb4e079ec58883b7251539fa10aeb"
-dependencies = [
- "build_const",
-]
 
 [[package]]
 name = "crypto-mac"
@@ -539,7 +524,6 @@ name = "fog-types"
 version = "1.0.0"
 dependencies = [
  "blake2",
- "crc",
  "displaydoc",
  "fog-kex-rng",
  "mc-crypto-keys",

--- a/fog/view/protocol/src/user_private.rs
+++ b/fog/view/protocol/src/user_private.rs
@@ -108,7 +108,7 @@ impl From<&AccountKey> for UserPrivate {
 mod testing {
     use super::*;
     use core::convert::TryFrom;
-    use fog_types::view::{FogTxOut, FogTxOutMetadata};
+    use fog_types::view::FogTxOut;
     use mc_crypto_box::{CryptoBox, VersionedCryptoBox};
     use mc_crypto_keys::CompressedRistrettoPublic;
     use mc_transaction_core::{fog_hint::FogHint, tx::TxOut};
@@ -161,12 +161,16 @@ mod testing {
 
         // Prep for DB record
         let fog_txout = FogTxOut::from(&txo);
-        let meta = FogTxOutMetadata {
-            global_index: 1,
+        let commitment_bytes: &[u8; 32] = fog_txout.amount.commitment.as_ref();
+        let txo_record = TxOutRecord {
+            tx_out_amount_commitment_data: commitment_bytes.to_vec(),
+            tx_out_amount_masked_value: fog_txout.amount.masked_value,
+            tx_out_target_key_data: fog_txout.target_key.as_bytes().to_vec(),
+            tx_out_public_key_data: fog_txout.public_key.as_bytes().to_vec(),
+            tx_out_global_index: 1,
             block_index: 1,
             timestamp: 42,
         };
-        let txo_record = TxOutRecord::new(fog_txout, meta);
 
         let protobuf = mc_util_serial::encode(&txo_record);
 


### PR DESCRIPTION
This reverts commit 1e1fc1c4fb4ddf50801b4f845a943a65593af497.

This is a breaking change, but we need to test the fee changes first,
so we will revert this for now and re-apply it later

Changes to be committed:
	modified:   Cargo.lock
	modified:   fog/api/proto/view.proto
	modified:   fog/api/tests/fog_types.rs
	modified:   fog/fog_types/Cargo.toml
	modified:   fog/fog_types/src/view.rs
	modified:   fog/ingest/enclave/impl/src/lib.rs
	modified:   fog/ingest/enclave/impl/tests/tx_processing.rs
	modified:   fog/ingest/enclave/trusted/Cargo.lock
	modified:   fog/ledger/enclave/trusted/Cargo.lock
	modified:   fog/sample-paykit/src/cached_tx_data/mod.rs
	modified:   fog/sample-paykit/src/client.rs
	modified:   fog/sample-paykit/src/error.rs
	modified:   fog/test_infra/src/mock_users.rs
	modified:   fog/view/enclave/trusted/Cargo.lock
	modified:   fog/view/protocol/src/user_private.rs