### PR TITLE
Bump version to 1.1.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@
 version: 2.1
 
 defaults:
-  builder-install: &builder-install gcr.io/mobilenode-211420/builder-install:1_19
+  builder-install: &builder-install gcr.io/mobilenode-211420/builder-install:1_20
   android-bindings-builder: &android-bindings-builder gcr.io/mobilenode-211420/android-bindings-builder:1_3
   default-xcode-version: &default-xcode-version "12.0.0"
 

--- a/.mobconf
+++ b/.mobconf
@@ -1,4 +1,4 @@
 [image]
 target = builder-install
 repository = gcr.io/mobilenode-211420/
-Dockerfile-version = 1_19
+Dockerfile-version = 1_20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,50 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+The crates in this repository do not adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) at this time.
+
+## [Unreleased]
+
+## [1.1.0-pre1 Unreleased]
+
+### Added
+
+ - Unified fog URI
+ - Cookie support for fog enclave connections
+
+### Changed
+
+ - Bump mobilecoin revision to 1.1.0-pre2
+ - Upgrade Rust to nightly-2021-03-25
+
+#### Rust Dependencies
+
+ - Update `aligned-cmov` to 2.0.0
+ - Update `arrayvec` to 0.5.2
+ - Update `balanced-tree-index` to 2.0.0
+ - Update `merlin` to 3.0.0
+ - Update `merlin` to 3.0.0
+ - Update `packed_simd` to 0.3.4
+ - Update `pv-lite86` to 0.2.10
+ - Update `protobuf` to 2.22.1
+ - Update `rand_chacha` to 0.3.0
+ - Update `rand_core` to 0.6.2
+ - Update `rand_hc` to 0.3.0
+ - Update `rand` to 0.8.3
+ - Update `schnorrkel` to 0.10.1
+ - Update `sha2` to 0.9.3
+ - Update `x25519-dalek` to 1.1.1
+
+### Fixed
+
+ - Improve conformance test
+
+### Security
+
+ - Add threat model document
+
+## [1.0.0] - 2021-04-05
+
+Initial release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The crates in this repository do not adhere to [Semantic Versioning](https://sem
 
 ## [Unreleased]
 
-## [1.1.0-pre1 Unreleased]
+## [1.1.0] 2021-05-14
 
 ### Added
 
@@ -16,7 +16,7 @@ The crates in this repository do not adhere to [Semantic Versioning](https://sem
 
 ### Changed
 
- - Bump mobilecoin revision to 1.1.0-pre2
+ - Bump mobilecoin submodule to 1.1.0
  - Upgrade Rust to nightly-2021-03-25
 
 #### Rust Dependencies

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1070,7 +1070,7 @@ checksum = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
 
 [[package]]
 name = "fog-api"
-version = "1.0.0"
+version = "1.1.0-pre2"
 dependencies = [
  "cargo-emit",
  "fog-enclave-connection",
@@ -1099,7 +1099,7 @@ dependencies = [
 
 [[package]]
 name = "fog-distribution"
-version = "1.0.0"
+version = "1.1.0-pre2"
 dependencies = [
  "crossbeam-channel 0.5.0",
  "curve25519-dalek",
@@ -1129,7 +1129,7 @@ dependencies = [
 
 [[package]]
 name = "fog-enclave-connection"
-version = "1.0.0"
+version = "1.1.0-pre2"
 dependencies = [
  "aes-gcm",
  "cookie",
@@ -1151,7 +1151,7 @@ dependencies = [
 
 [[package]]
 name = "fog-ingest-client"
-version = "1.0.0"
+version = "1.1.0-pre2"
 dependencies = [
  "displaydoc",
  "fog-api",
@@ -1174,7 +1174,7 @@ dependencies = [
 
 [[package]]
 name = "fog-ingest-enclave"
-version = "1.0.0"
+version = "1.1.0-pre2"
 dependencies = [
  "cargo-emit",
  "criterion",
@@ -1207,7 +1207,7 @@ dependencies = [
 
 [[package]]
 name = "fog-ingest-enclave-api"
-version = "1.0.0"
+version = "1.1.0-pre2"
 dependencies = [
  "displaydoc",
  "fog-kex-rng",
@@ -1224,7 +1224,7 @@ dependencies = [
 
 [[package]]
 name = "fog-ingest-enclave-edl"
-version = "1.0.0"
+version = "1.1.0-pre2"
 dependencies = [
  "cargo-emit",
  "mc-util-build-script",
@@ -1232,7 +1232,7 @@ dependencies = [
 
 [[package]]
 name = "fog-ingest-enclave-impl"
-version = "1.0.0"
+version = "1.1.0-pre2"
 dependencies = [
  "aligned-cmov",
  "fog-ingest-enclave-api",
@@ -1265,7 +1265,7 @@ dependencies = [
 
 [[package]]
 name = "fog-ingest-enclave-measurement"
-version = "1.0.0"
+version = "1.1.0-pre2"
 dependencies = [
  "cargo-emit",
  "mc-attest-core",
@@ -1277,7 +1277,7 @@ dependencies = [
 
 [[package]]
 name = "fog-ingest-server"
-version = "1.0.0"
+version = "1.1.0-pre2"
 dependencies = [
  "dirs",
  "displaydoc",
@@ -1331,7 +1331,7 @@ dependencies = [
 
 [[package]]
 name = "fog-kex-rng"
-version = "1.0.0"
+version = "1.1.0-pre2"
 dependencies = [
  "blake2",
  "displaydoc",
@@ -1346,7 +1346,7 @@ dependencies = [
 
 [[package]]
 name = "fog-ledger-connection"
-version = "1.0.0"
+version = "1.1.0-pre2"
 dependencies = [
  "displaydoc",
  "fog-api",
@@ -1366,7 +1366,7 @@ dependencies = [
 
 [[package]]
 name = "fog-ledger-enclave"
-version = "1.0.0"
+version = "1.1.0-pre2"
 dependencies = [
  "cargo-emit",
  "fog-ledger-enclave-api",
@@ -1390,7 +1390,7 @@ dependencies = [
 
 [[package]]
 name = "fog-ledger-enclave-api"
-version = "1.0.0"
+version = "1.1.0-pre2"
 dependencies = [
  "displaydoc",
  "fog-types",
@@ -1408,7 +1408,7 @@ dependencies = [
 
 [[package]]
 name = "fog-ledger-enclave-edl"
-version = "1.0.0"
+version = "1.1.0-pre2"
 dependencies = [
  "cargo-emit",
  "mc-util-build-script",
@@ -1416,7 +1416,7 @@ dependencies = [
 
 [[package]]
 name = "fog-ledger-enclave-impl"
-version = "1.0.0"
+version = "1.1.0-pre2"
 dependencies = [
  "fog-ledger-enclave-api",
  "fog-types",
@@ -1431,7 +1431,7 @@ dependencies = [
 
 [[package]]
 name = "fog-ledger-enclave-measurement"
-version = "1.0.0"
+version = "1.1.0-pre2"
 dependencies = [
  "cargo-emit",
  "mc-attest-core",
@@ -1443,7 +1443,7 @@ dependencies = [
 
 [[package]]
 name = "fog-ledger-server"
-version = "1.0.0"
+version = "1.1.0-pre2"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -1490,7 +1490,7 @@ dependencies = [
 
 [[package]]
 name = "fog-ledger-test-infra"
-version = "1.0.0"
+version = "1.1.0-pre2"
 dependencies = [
  "curve25519-dalek",
  "fog-ledger-enclave",
@@ -1505,7 +1505,7 @@ dependencies = [
 
 [[package]]
 name = "fog-load-testing"
-version = "1.0.0"
+version = "1.1.0-pre2"
 dependencies = [
  "arrayvec",
  "fog-api",
@@ -1536,14 +1536,14 @@ dependencies = [
 
 [[package]]
 name = "fog-ocall-oram-storage-edl"
-version = "0.5.0"
+version = "1.1.0-pre2"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "fog-ocall-oram-storage-testing"
-version = "0.5.0"
+version = "1.1.0-pre2"
 dependencies = [
  "aligned-cmov",
  "fog-ocall-oram-storage-trusted",
@@ -1554,7 +1554,7 @@ dependencies = [
 
 [[package]]
 name = "fog-ocall-oram-storage-trusted"
-version = "0.5.0"
+version = "1.1.0-pre2"
 dependencies = [
  "aes-ctr",
  "aligned-cmov",
@@ -1570,7 +1570,7 @@ dependencies = [
 
 [[package]]
 name = "fog-ocall-oram-storage-untrusted"
-version = "0.5.0"
+version = "1.1.0-pre2"
 dependencies = [
  "lazy_static",
  "mc-common",
@@ -1578,7 +1578,7 @@ dependencies = [
 
 [[package]]
 name = "fog-recovery-db-iface"
-version = "1.0.0"
+version = "1.1.0-pre2"
 dependencies = [
  "displaydoc",
  "fog-kex-rng",
@@ -1592,7 +1592,7 @@ dependencies = [
 
 [[package]]
 name = "fog-report-cli"
-version = "0.9.0"
+version = "1.1.0-pre2"
 dependencies = [
  "binascii",
  "fog-ingest-enclave-measurement",
@@ -1610,7 +1610,7 @@ dependencies = [
 
 [[package]]
 name = "fog-report-server"
-version = "1.0.0"
+version = "1.1.0-pre2"
 dependencies = [
  "displaydoc",
  "fog-api",
@@ -1644,7 +1644,7 @@ dependencies = [
 
 [[package]]
 name = "fog-sample-paykit"
-version = "1.0.0"
+version = "1.1.0-pre2"
 dependencies = [
  "cargo-emit",
  "displaydoc",
@@ -1687,7 +1687,7 @@ dependencies = [
 
 [[package]]
 name = "fog-sql-recovery-db"
-version = "1.0.0"
+version = "1.1.0-pre2"
 dependencies = [
  "chrono",
  "diesel",
@@ -1716,7 +1716,7 @@ dependencies = [
 
 [[package]]
 name = "fog-test-client"
-version = "1.0.0"
+version = "1.1.0-pre2"
 dependencies = [
  "fog-sample-paykit",
  "mc-common",
@@ -1730,7 +1730,7 @@ dependencies = [
 
 [[package]]
 name = "fog-test-infra"
-version = "1.0.0"
+version = "1.1.0-pre2"
 dependencies = [
  "curve25519-dalek",
  "digest",
@@ -1762,7 +1762,7 @@ dependencies = [
 
 [[package]]
 name = "fog-types"
-version = "1.0.0"
+version = "1.1.0-pre2"
 dependencies = [
  "blake2",
  "displaydoc",
@@ -1777,7 +1777,7 @@ dependencies = [
 
 [[package]]
 name = "fog-uri"
-version = "1.0.0"
+version = "1.1.0-pre2"
 dependencies = [
  "mc-common",
  "mc-util-uri",
@@ -1785,7 +1785,7 @@ dependencies = [
 
 [[package]]
 name = "fog-view-connection"
-version = "1.0.0"
+version = "1.1.0-pre2"
 dependencies = [
  "fog-api",
  "fog-enclave-connection",
@@ -1802,7 +1802,7 @@ dependencies = [
 
 [[package]]
 name = "fog-view-enclave"
-version = "1.0.0"
+version = "1.1.0-pre2"
 dependencies = [
  "cargo-emit",
  "criterion",
@@ -1839,7 +1839,7 @@ dependencies = [
 
 [[package]]
 name = "fog-view-enclave-api"
-version = "1.0.0"
+version = "1.1.0-pre2"
 dependencies = [
  "displaydoc",
  "fog-recovery-db-iface",
@@ -1857,7 +1857,7 @@ dependencies = [
 
 [[package]]
 name = "fog-view-enclave-edl"
-version = "1.0.0"
+version = "1.1.0-pre2"
 dependencies = [
  "cargo-emit",
  "mc-util-build-script",
@@ -1865,7 +1865,7 @@ dependencies = [
 
 [[package]]
 name = "fog-view-enclave-impl"
-version = "1.0.0"
+version = "1.1.0-pre2"
 dependencies = [
  "aligned-cmov",
  "fog-recovery-db-iface",
@@ -1887,7 +1887,7 @@ dependencies = [
 
 [[package]]
 name = "fog-view-enclave-measurement"
-version = "1.0.0"
+version = "1.1.0-pre2"
 dependencies = [
  "cargo-emit",
  "mc-attest-core",
@@ -1899,7 +1899,7 @@ dependencies = [
 
 [[package]]
 name = "fog-view-load-test"
-version = "0.10.0"
+version = "1.1.0-pre2"
 dependencies = [
  "fog-kex-rng",
  "fog-uri",
@@ -1916,7 +1916,7 @@ dependencies = [
 
 [[package]]
 name = "fog-view-protocol"
-version = "1.0.0"
+version = "1.1.0-pre2"
 dependencies = [
  "blake2",
  "displaydoc",
@@ -1939,7 +1939,7 @@ dependencies = [
 
 [[package]]
 name = "fog-view-server"
-version = "1.0.0"
+version = "1.1.0-pre2"
 dependencies = [
  "displaydoc",
  "fog-api",
@@ -2732,7 +2732,7 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "blake2",
  "curve25519-dalek",
@@ -2752,7 +2752,7 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys-slip10"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -2767,7 +2767,7 @@ dependencies = [
 
 [[package]]
 name = "mc-android-bindings"
-version = "1.0.0"
+version = "1.1.0-pre2"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2802,7 +2802,7 @@ dependencies = [
 
 [[package]]
 name = "mc-api"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "bs58",
  "cargo-emit",
@@ -2823,7 +2823,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-ake"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "aead",
  "cargo-emit",
@@ -2841,7 +2841,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-api"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "aead",
  "cargo-emit",
@@ -2859,7 +2859,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-core"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "binascii",
  "bitflags",
@@ -2892,7 +2892,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-enclave-api"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "displaydoc",
  "mc-attest-ake",
@@ -2904,7 +2904,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-net"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "cfg-if 0.1.10",
  "failure",
@@ -2922,7 +2922,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-trusted"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "failure",
  "mc-attest-core",
@@ -2933,7 +2933,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-untrusted"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "mc-attest-core",
  "mc-sgx-build",
@@ -2942,7 +2942,7 @@ dependencies = [
 
 [[package]]
 name = "mc-common"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "backtrace",
  "binascii",
@@ -2977,7 +2977,7 @@ dependencies = [
 
 [[package]]
 name = "mc-connection"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "aes-gcm",
  "cookie",
@@ -3002,7 +3002,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-api"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "cargo-emit",
  "futures",
@@ -3017,7 +3017,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "cargo-emit",
  "mc-attest-core",
@@ -3041,7 +3041,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-api"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "failure",
  "mc-attest-ake",
@@ -3059,7 +3059,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-edl"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "cargo-emit",
  "mc-util-build-script",
@@ -3067,7 +3067,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-measurement"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "cargo-emit",
  "mc-attest-core",
@@ -3079,7 +3079,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-scp"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "bigint",
  "maplit",
@@ -3097,7 +3097,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-service"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "base64 0.12.3",
  "chrono",
@@ -3142,7 +3142,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ake-enclave"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "aes-gcm",
  "digest",
@@ -3161,7 +3161,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-box"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "aes-gcm",
  "blake2",
@@ -3175,7 +3175,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ct-aead"
-version = "0.5.0"
+version = "1.1.0-pre2"
 dependencies = [
  "aead",
  "aes-gcm",
@@ -3185,7 +3185,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "cfg-if 0.1.10",
  "curve25519-dalek",
@@ -3198,7 +3198,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-derive"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.2",
@@ -3207,7 +3207,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-signature"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "mc-crypto-digestible",
  "schnorrkel",
@@ -3216,7 +3216,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-hashes"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "blake2",
  "digest",
@@ -3225,7 +3225,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-keys"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "binascii",
  "curve25519-dalek",
@@ -3250,7 +3250,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-message-cipher"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "aes-gcm",
  "failure",
@@ -3263,7 +3263,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-noise"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "aead",
  "aes-gcm",
@@ -3283,7 +3283,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-rand"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "cfg-if 0.1.10",
  "getrandom 0.1.14",
@@ -3294,7 +3294,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-sig"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "mc-crypto-keys",
  "merlin",
@@ -3305,7 +3305,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-x509-test-vectors"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "cargo-emit",
  "mc-crypto-keys",
@@ -3317,7 +3317,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-x509-utils"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "displaydoc",
  "mc-crypto-keys",
@@ -3327,7 +3327,7 @@ dependencies = [
 
 [[package]]
 name = "mc-enclave-boundary"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "mc-common",
  "mc-crypto-rand",
@@ -3338,7 +3338,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-api"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "cargo-emit",
  "futures",
@@ -3354,7 +3354,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-api-test-utils"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "mc-util-serial",
  "prost",
@@ -3363,7 +3363,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-connection"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "displaydoc",
  "grpcio",
@@ -3380,7 +3380,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-validation"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "displaydoc",
  "mc-account-keys",
@@ -3395,7 +3395,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-validation-test-utils"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "mc-account-keys",
  "mc-fog-report-validation",
@@ -3403,7 +3403,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "displaydoc",
  "mc-account-keys",
@@ -3419,7 +3419,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig-authority"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "mc-crypto-keys",
  "signature",
@@ -3427,7 +3427,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig-report"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -3439,7 +3439,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-types"
-version = "0.10.0"
+version = "1.1.0-pre2"
 dependencies = [
  "mc-attest-core",
  "mc-crypto-digestible",
@@ -3449,7 +3449,7 @@ dependencies = [
 
 [[package]]
 name = "mc-ledger-db"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "curve25519-dalek",
  "failure",
@@ -3470,7 +3470,7 @@ dependencies = [
 
 [[package]]
 name = "mc-ledger-sync"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "crossbeam-channel 0.5.0",
  "failure",
@@ -3498,7 +3498,7 @@ dependencies = [
 
 [[package]]
 name = "mc-mobilecoind"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "aes-gcm",
  "blake2",
@@ -3550,7 +3550,7 @@ dependencies = [
 
 [[package]]
 name = "mc-mobilecoind-api"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "cargo-emit",
  "futures",
@@ -3601,7 +3601,7 @@ dependencies = [
 
 [[package]]
 name = "mc-peers"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "crossbeam-channel 0.5.0",
  "ed25519",
@@ -3630,7 +3630,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-build"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "cc",
  "lazy_static",
@@ -3640,7 +3640,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-compat"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "cfg-if 0.1.10",
  "mc-sgx-types",
@@ -3648,7 +3648,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-css"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "displaydoc",
  "sha2",
@@ -3656,21 +3656,21 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-debug-edl"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-panic-edl"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-report-cache-api"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -3681,7 +3681,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-report-cache-untrusted"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -3696,7 +3696,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "cfg-if 0.1.10",
  "mc-common",
@@ -3706,18 +3706,18 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog-edl"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-types"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 
 [[package]]
 name = "mc-sgx-urts"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "mc-common",
  "mc-sgx-build",
@@ -3728,7 +3728,7 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-core"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "blake2",
  "bulletproofs",
@@ -3756,7 +3756,7 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-core-test-utils"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "mc-account-keys",
  "mc-crypto-keys",
@@ -3772,7 +3772,7 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-std"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "blake2",
  "curve25519-dalek",
@@ -3791,7 +3791,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-enclave"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "cargo-emit",
  "cargo_metadata 0.9.1",
@@ -3807,7 +3807,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-grpc"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "mc-util-build-script",
  "protoc-grpcio",
@@ -3815,11 +3815,11 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-info"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 
 [[package]]
 name = "mc-util-build-script"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "cargo-emit",
  "failure",
@@ -3830,7 +3830,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-sgx"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "cargo-emit",
  "cc",
@@ -3841,7 +3841,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-encodings"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "base64 0.12.3",
  "binascii",
@@ -3857,14 +3857,14 @@ version = "1.0.0"
 
 [[package]]
 name = "mc-util-from-random"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "rand_core 0.6.2",
 ]
 
 [[package]]
 name = "mc-util-generate-sample-ledger"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "curve25519-dalek",
  "hex 0.3.2",
@@ -3884,7 +3884,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-grpc"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "base64 0.12.3",
  "cookie",
@@ -3912,11 +3912,11 @@ dependencies = [
 
 [[package]]
 name = "mc-util-host-cert"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 
 [[package]]
 name = "mc-util-keyfile"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "hex 0.4.2",
  "mc-account-keys",
@@ -3934,7 +3934,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-lmdb"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "displaydoc",
  "lmdb-rkv",
@@ -3944,7 +3944,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-logger-macros"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "proc-macro2 0.4.30",
  "quote 0.6.13",
@@ -3953,7 +3953,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-metered-channel"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "crossbeam-channel 0.5.0",
  "mc-util-metrics",
@@ -3961,7 +3961,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-metrics"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "chrono",
  "grpcio",
@@ -3974,7 +3974,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-repr-bytes"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "generic-array",
  "prost",
@@ -3983,7 +3983,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-serial"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "prost",
  "serde",
@@ -3992,7 +3992,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-test-helper"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "lazy_static",
  "mc-account-keys",
@@ -4004,7 +4004,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-uri"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "base64 0.12.3",
  "displaydoc",
@@ -4020,7 +4020,7 @@ dependencies = [
 
 [[package]]
 name = "mc-watcher"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "displaydoc",
  "grpcio",
@@ -4053,7 +4053,7 @@ dependencies = [
 
 [[package]]
 name = "mc-watcher-api"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "displaydoc",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -243,7 +243,7 @@ checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "benchmarks"
-version = "1.0.0"
+version = "1.1.0-pre2"
 dependencies = [
  "criterion",
  "mc-common",
@@ -2114,7 +2114,7 @@ dependencies = [
 
 [[package]]
 name = "generate_test_foundation_key"
-version = "1.0.0"
+version = "1.1.0-pre2"
 dependencies = [
  "mc-account-keys",
  "rand 0.8.3",
@@ -2588,7 +2588,7 @@ checksum = "7fc7aa29613bd6a620df431842069224d8bc9011086b1db4c0e0cd47fa03ec9a"
 
 [[package]]
 name = "libmobilecoin"
-version = "1.0.0"
+version = "1.1.0-pre2"
 dependencies = [
  "aes-gcm",
  "cbindgen",
@@ -3853,7 +3853,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-ffi"
-version = "1.0.0"
+version = "1.1.0-pre2"
 
 [[package]]
 name = "mc-util-from-random"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -243,7 +243,7 @@ checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "benchmarks"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "criterion",
  "mc-common",
@@ -1070,7 +1070,7 @@ checksum = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
 
 [[package]]
 name = "fog-api"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "cargo-emit",
  "fog-enclave-connection",
@@ -1099,7 +1099,7 @@ dependencies = [
 
 [[package]]
 name = "fog-distribution"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "crossbeam-channel 0.5.0",
  "curve25519-dalek",
@@ -1129,7 +1129,7 @@ dependencies = [
 
 [[package]]
 name = "fog-enclave-connection"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "aes-gcm",
  "cookie",
@@ -1151,7 +1151,7 @@ dependencies = [
 
 [[package]]
 name = "fog-ingest-client"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "displaydoc",
  "fog-api",
@@ -1174,7 +1174,7 @@ dependencies = [
 
 [[package]]
 name = "fog-ingest-enclave"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "cargo-emit",
  "criterion",
@@ -1207,7 +1207,7 @@ dependencies = [
 
 [[package]]
 name = "fog-ingest-enclave-api"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "displaydoc",
  "fog-kex-rng",
@@ -1224,7 +1224,7 @@ dependencies = [
 
 [[package]]
 name = "fog-ingest-enclave-edl"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "cargo-emit",
  "mc-util-build-script",
@@ -1232,7 +1232,7 @@ dependencies = [
 
 [[package]]
 name = "fog-ingest-enclave-impl"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "aligned-cmov",
  "fog-ingest-enclave-api",
@@ -1265,7 +1265,7 @@ dependencies = [
 
 [[package]]
 name = "fog-ingest-enclave-measurement"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "cargo-emit",
  "mc-attest-core",
@@ -1277,7 +1277,7 @@ dependencies = [
 
 [[package]]
 name = "fog-ingest-server"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "dirs",
  "displaydoc",
@@ -1331,7 +1331,7 @@ dependencies = [
 
 [[package]]
 name = "fog-kex-rng"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "blake2",
  "displaydoc",
@@ -1346,7 +1346,7 @@ dependencies = [
 
 [[package]]
 name = "fog-ledger-connection"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "displaydoc",
  "fog-api",
@@ -1366,7 +1366,7 @@ dependencies = [
 
 [[package]]
 name = "fog-ledger-enclave"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "cargo-emit",
  "fog-ledger-enclave-api",
@@ -1390,7 +1390,7 @@ dependencies = [
 
 [[package]]
 name = "fog-ledger-enclave-api"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "displaydoc",
  "fog-types",
@@ -1408,7 +1408,7 @@ dependencies = [
 
 [[package]]
 name = "fog-ledger-enclave-edl"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "cargo-emit",
  "mc-util-build-script",
@@ -1416,7 +1416,7 @@ dependencies = [
 
 [[package]]
 name = "fog-ledger-enclave-impl"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "fog-ledger-enclave-api",
  "fog-types",
@@ -1431,7 +1431,7 @@ dependencies = [
 
 [[package]]
 name = "fog-ledger-enclave-measurement"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "cargo-emit",
  "mc-attest-core",
@@ -1443,7 +1443,7 @@ dependencies = [
 
 [[package]]
 name = "fog-ledger-server"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -1490,7 +1490,7 @@ dependencies = [
 
 [[package]]
 name = "fog-ledger-test-infra"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "curve25519-dalek",
  "fog-ledger-enclave",
@@ -1505,7 +1505,7 @@ dependencies = [
 
 [[package]]
 name = "fog-load-testing"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "arrayvec",
  "fog-api",
@@ -1536,14 +1536,14 @@ dependencies = [
 
 [[package]]
 name = "fog-ocall-oram-storage-edl"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "fog-ocall-oram-storage-testing"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "aligned-cmov",
  "fog-ocall-oram-storage-trusted",
@@ -1554,7 +1554,7 @@ dependencies = [
 
 [[package]]
 name = "fog-ocall-oram-storage-trusted"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "aes-ctr",
  "aligned-cmov",
@@ -1570,7 +1570,7 @@ dependencies = [
 
 [[package]]
 name = "fog-ocall-oram-storage-untrusted"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "lazy_static",
  "mc-common",
@@ -1578,7 +1578,7 @@ dependencies = [
 
 [[package]]
 name = "fog-recovery-db-iface"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "displaydoc",
  "fog-kex-rng",
@@ -1592,7 +1592,7 @@ dependencies = [
 
 [[package]]
 name = "fog-report-cli"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "binascii",
  "fog-ingest-enclave-measurement",
@@ -1610,7 +1610,7 @@ dependencies = [
 
 [[package]]
 name = "fog-report-server"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "displaydoc",
  "fog-api",
@@ -1644,7 +1644,7 @@ dependencies = [
 
 [[package]]
 name = "fog-sample-paykit"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "cargo-emit",
  "displaydoc",
@@ -1687,7 +1687,7 @@ dependencies = [
 
 [[package]]
 name = "fog-sql-recovery-db"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "chrono",
  "diesel",
@@ -1716,7 +1716,7 @@ dependencies = [
 
 [[package]]
 name = "fog-test-client"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "fog-sample-paykit",
  "mc-common",
@@ -1730,7 +1730,7 @@ dependencies = [
 
 [[package]]
 name = "fog-test-infra"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "curve25519-dalek",
  "digest",
@@ -1762,7 +1762,7 @@ dependencies = [
 
 [[package]]
 name = "fog-types"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "blake2",
  "displaydoc",
@@ -1777,7 +1777,7 @@ dependencies = [
 
 [[package]]
 name = "fog-uri"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "mc-common",
  "mc-util-uri",
@@ -1785,7 +1785,7 @@ dependencies = [
 
 [[package]]
 name = "fog-view-connection"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "fog-api",
  "fog-enclave-connection",
@@ -1802,7 +1802,7 @@ dependencies = [
 
 [[package]]
 name = "fog-view-enclave"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "cargo-emit",
  "criterion",
@@ -1839,7 +1839,7 @@ dependencies = [
 
 [[package]]
 name = "fog-view-enclave-api"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "displaydoc",
  "fog-recovery-db-iface",
@@ -1857,7 +1857,7 @@ dependencies = [
 
 [[package]]
 name = "fog-view-enclave-edl"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "cargo-emit",
  "mc-util-build-script",
@@ -1865,7 +1865,7 @@ dependencies = [
 
 [[package]]
 name = "fog-view-enclave-impl"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "aligned-cmov",
  "fog-recovery-db-iface",
@@ -1887,7 +1887,7 @@ dependencies = [
 
 [[package]]
 name = "fog-view-enclave-measurement"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "cargo-emit",
  "mc-attest-core",
@@ -1899,7 +1899,7 @@ dependencies = [
 
 [[package]]
 name = "fog-view-load-test"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "fog-kex-rng",
  "fog-uri",
@@ -1916,7 +1916,7 @@ dependencies = [
 
 [[package]]
 name = "fog-view-protocol"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "blake2",
  "displaydoc",
@@ -1939,7 +1939,7 @@ dependencies = [
 
 [[package]]
 name = "fog-view-server"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "displaydoc",
  "fog-api",
@@ -2114,7 +2114,7 @@ dependencies = [
 
 [[package]]
 name = "generate_test_foundation_key"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "mc-account-keys",
  "rand 0.8.3",
@@ -2588,7 +2588,7 @@ checksum = "7fc7aa29613bd6a620df431842069224d8bc9011086b1db4c0e0cd47fa03ec9a"
 
 [[package]]
 name = "libmobilecoin"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "aes-gcm",
  "cbindgen",
@@ -2732,7 +2732,7 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "blake2",
  "curve25519-dalek",
@@ -2752,7 +2752,7 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys-slip10"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -2767,7 +2767,7 @@ dependencies = [
 
 [[package]]
 name = "mc-android-bindings"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2802,7 +2802,7 @@ dependencies = [
 
 [[package]]
 name = "mc-api"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "bs58",
  "cargo-emit",
@@ -2823,7 +2823,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-ake"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "aead",
  "cargo-emit",
@@ -2841,7 +2841,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-api"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "aead",
  "cargo-emit",
@@ -2859,7 +2859,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-core"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "binascii",
  "bitflags",
@@ -2892,7 +2892,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-enclave-api"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "displaydoc",
  "mc-attest-ake",
@@ -2904,7 +2904,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-net"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "cfg-if 0.1.10",
  "failure",
@@ -2922,7 +2922,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-trusted"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "failure",
  "mc-attest-core",
@@ -2933,7 +2933,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-untrusted"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "mc-attest-core",
  "mc-sgx-build",
@@ -2942,7 +2942,7 @@ dependencies = [
 
 [[package]]
 name = "mc-common"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "backtrace",
  "binascii",
@@ -2977,7 +2977,7 @@ dependencies = [
 
 [[package]]
 name = "mc-connection"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "aes-gcm",
  "cookie",
@@ -3002,7 +3002,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-api"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "cargo-emit",
  "futures",
@@ -3017,7 +3017,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "cargo-emit",
  "mc-attest-core",
@@ -3041,7 +3041,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-api"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "failure",
  "mc-attest-ake",
@@ -3059,7 +3059,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-edl"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "cargo-emit",
  "mc-util-build-script",
@@ -3067,7 +3067,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-measurement"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "cargo-emit",
  "mc-attest-core",
@@ -3079,7 +3079,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-scp"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "bigint",
  "maplit",
@@ -3097,7 +3097,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-service"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "base64 0.12.3",
  "chrono",
@@ -3142,7 +3142,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ake-enclave"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "aes-gcm",
  "digest",
@@ -3161,7 +3161,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-box"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "aes-gcm",
  "blake2",
@@ -3175,7 +3175,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ct-aead"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "aead",
  "aes-gcm",
@@ -3185,7 +3185,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "cfg-if 0.1.10",
  "curve25519-dalek",
@@ -3198,7 +3198,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-derive"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.2",
@@ -3207,7 +3207,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-signature"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "mc-crypto-digestible",
  "schnorrkel",
@@ -3216,7 +3216,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-hashes"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "blake2",
  "digest",
@@ -3225,7 +3225,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-keys"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "binascii",
  "curve25519-dalek",
@@ -3250,7 +3250,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-message-cipher"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "aes-gcm",
  "failure",
@@ -3263,7 +3263,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-noise"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "aead",
  "aes-gcm",
@@ -3283,7 +3283,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-rand"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "cfg-if 0.1.10",
  "getrandom 0.1.14",
@@ -3294,7 +3294,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-sig"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "mc-crypto-keys",
  "merlin",
@@ -3305,7 +3305,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-x509-test-vectors"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "cargo-emit",
  "mc-crypto-keys",
@@ -3317,7 +3317,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-x509-utils"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "displaydoc",
  "mc-crypto-keys",
@@ -3327,7 +3327,7 @@ dependencies = [
 
 [[package]]
 name = "mc-enclave-boundary"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "mc-common",
  "mc-crypto-rand",
@@ -3338,7 +3338,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-api"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "cargo-emit",
  "futures",
@@ -3354,7 +3354,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-api-test-utils"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "mc-util-serial",
  "prost",
@@ -3363,7 +3363,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-connection"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "displaydoc",
  "grpcio",
@@ -3380,7 +3380,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-validation"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "displaydoc",
  "mc-account-keys",
@@ -3395,7 +3395,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-validation-test-utils"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "mc-account-keys",
  "mc-fog-report-validation",
@@ -3403,7 +3403,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "displaydoc",
  "mc-account-keys",
@@ -3419,7 +3419,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig-authority"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "mc-crypto-keys",
  "signature",
@@ -3427,7 +3427,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig-report"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -3439,7 +3439,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-types"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "mc-attest-core",
  "mc-crypto-digestible",
@@ -3449,7 +3449,7 @@ dependencies = [
 
 [[package]]
 name = "mc-ledger-db"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "curve25519-dalek",
  "failure",
@@ -3470,7 +3470,7 @@ dependencies = [
 
 [[package]]
 name = "mc-ledger-sync"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "crossbeam-channel 0.5.0",
  "failure",
@@ -3498,7 +3498,7 @@ dependencies = [
 
 [[package]]
 name = "mc-mobilecoind"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "aes-gcm",
  "blake2",
@@ -3550,7 +3550,7 @@ dependencies = [
 
 [[package]]
 name = "mc-mobilecoind-api"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "cargo-emit",
  "futures",
@@ -3601,7 +3601,7 @@ dependencies = [
 
 [[package]]
 name = "mc-peers"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "crossbeam-channel 0.5.0",
  "ed25519",
@@ -3630,7 +3630,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-build"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "cc",
  "lazy_static",
@@ -3640,7 +3640,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-compat"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "cfg-if 0.1.10",
  "mc-sgx-types",
@@ -3648,7 +3648,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-css"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "displaydoc",
  "sha2",
@@ -3656,21 +3656,21 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-debug-edl"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-panic-edl"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-report-cache-api"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -3681,7 +3681,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-report-cache-untrusted"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -3696,7 +3696,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "cfg-if 0.1.10",
  "mc-common",
@@ -3706,18 +3706,18 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog-edl"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-types"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 
 [[package]]
 name = "mc-sgx-urts"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "mc-common",
  "mc-sgx-build",
@@ -3728,7 +3728,7 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-core"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "blake2",
  "bulletproofs",
@@ -3756,7 +3756,7 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-core-test-utils"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "mc-account-keys",
  "mc-crypto-keys",
@@ -3772,7 +3772,7 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-std"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "blake2",
  "curve25519-dalek",
@@ -3791,7 +3791,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-enclave"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "cargo-emit",
  "cargo_metadata 0.9.1",
@@ -3807,7 +3807,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-grpc"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "mc-util-build-script",
  "protoc-grpcio",
@@ -3815,11 +3815,11 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-info"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 
 [[package]]
 name = "mc-util-build-script"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "cargo-emit",
  "failure",
@@ -3830,7 +3830,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-sgx"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "cargo-emit",
  "cc",
@@ -3841,7 +3841,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-encodings"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "base64 0.12.3",
  "binascii",
@@ -3853,18 +3853,18 @@ dependencies = [
 
 [[package]]
 name = "mc-util-ffi"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 
 [[package]]
 name = "mc-util-from-random"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "rand_core 0.6.2",
 ]
 
 [[package]]
 name = "mc-util-generate-sample-ledger"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "curve25519-dalek",
  "hex 0.3.2",
@@ -3884,7 +3884,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-grpc"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "base64 0.12.3",
  "cookie",
@@ -3912,11 +3912,11 @@ dependencies = [
 
 [[package]]
 name = "mc-util-host-cert"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 
 [[package]]
 name = "mc-util-keyfile"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "hex 0.4.2",
  "mc-account-keys",
@@ -3934,7 +3934,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-lmdb"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "displaydoc",
  "lmdb-rkv",
@@ -3944,7 +3944,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-logger-macros"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "proc-macro2 0.4.30",
  "quote 0.6.13",
@@ -3953,7 +3953,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-metered-channel"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "crossbeam-channel 0.5.0",
  "mc-util-metrics",
@@ -3961,7 +3961,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-metrics"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "chrono",
  "grpcio",
@@ -3974,7 +3974,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-repr-bytes"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "generic-array",
  "prost",
@@ -3983,7 +3983,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-serial"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "prost",
  "serde",
@@ -3992,7 +3992,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-test-helper"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "lazy_static",
  "mc-account-keys",
@@ -4004,7 +4004,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-uri"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "base64 0.12.3",
  "displaydoc",
@@ -4020,7 +4020,7 @@ dependencies = [
 
 [[package]]
 name = "mc-watcher"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "displaydoc",
  "grpcio",
@@ -4053,7 +4053,7 @@ dependencies = [
 
 [[package]]
 name = "mc-watcher-api"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "displaydoc",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -243,7 +243,7 @@ checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "benchmarks"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "criterion",
  "mc-common",
@@ -1070,7 +1070,7 @@ checksum = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
 
 [[package]]
 name = "fog-api"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "cargo-emit",
  "fog-enclave-connection",
@@ -1099,7 +1099,7 @@ dependencies = [
 
 [[package]]
 name = "fog-distribution"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "crossbeam-channel 0.5.0",
  "curve25519-dalek",
@@ -1129,7 +1129,7 @@ dependencies = [
 
 [[package]]
 name = "fog-enclave-connection"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "aes-gcm",
  "cookie",
@@ -1151,7 +1151,7 @@ dependencies = [
 
 [[package]]
 name = "fog-ingest-client"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "displaydoc",
  "fog-api",
@@ -1174,7 +1174,7 @@ dependencies = [
 
 [[package]]
 name = "fog-ingest-enclave"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "cargo-emit",
  "criterion",
@@ -1207,7 +1207,7 @@ dependencies = [
 
 [[package]]
 name = "fog-ingest-enclave-api"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "displaydoc",
  "fog-kex-rng",
@@ -1224,7 +1224,7 @@ dependencies = [
 
 [[package]]
 name = "fog-ingest-enclave-edl"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "cargo-emit",
  "mc-util-build-script",
@@ -1232,7 +1232,7 @@ dependencies = [
 
 [[package]]
 name = "fog-ingest-enclave-impl"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "aligned-cmov",
  "fog-ingest-enclave-api",
@@ -1265,7 +1265,7 @@ dependencies = [
 
 [[package]]
 name = "fog-ingest-enclave-measurement"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "cargo-emit",
  "mc-attest-core",
@@ -1277,7 +1277,7 @@ dependencies = [
 
 [[package]]
 name = "fog-ingest-server"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "dirs",
  "displaydoc",
@@ -1331,7 +1331,7 @@ dependencies = [
 
 [[package]]
 name = "fog-kex-rng"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "blake2",
  "displaydoc",
@@ -1346,7 +1346,7 @@ dependencies = [
 
 [[package]]
 name = "fog-ledger-connection"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "displaydoc",
  "fog-api",
@@ -1366,7 +1366,7 @@ dependencies = [
 
 [[package]]
 name = "fog-ledger-enclave"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "cargo-emit",
  "fog-ledger-enclave-api",
@@ -1390,7 +1390,7 @@ dependencies = [
 
 [[package]]
 name = "fog-ledger-enclave-api"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "displaydoc",
  "fog-types",
@@ -1408,7 +1408,7 @@ dependencies = [
 
 [[package]]
 name = "fog-ledger-enclave-edl"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "cargo-emit",
  "mc-util-build-script",
@@ -1416,7 +1416,7 @@ dependencies = [
 
 [[package]]
 name = "fog-ledger-enclave-impl"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "fog-ledger-enclave-api",
  "fog-types",
@@ -1431,7 +1431,7 @@ dependencies = [
 
 [[package]]
 name = "fog-ledger-enclave-measurement"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "cargo-emit",
  "mc-attest-core",
@@ -1443,7 +1443,7 @@ dependencies = [
 
 [[package]]
 name = "fog-ledger-server"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -1490,7 +1490,7 @@ dependencies = [
 
 [[package]]
 name = "fog-ledger-test-infra"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "curve25519-dalek",
  "fog-ledger-enclave",
@@ -1505,7 +1505,7 @@ dependencies = [
 
 [[package]]
 name = "fog-load-testing"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "arrayvec",
  "fog-api",
@@ -1536,14 +1536,14 @@ dependencies = [
 
 [[package]]
 name = "fog-ocall-oram-storage-edl"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "fog-ocall-oram-storage-testing"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "aligned-cmov",
  "fog-ocall-oram-storage-trusted",
@@ -1554,7 +1554,7 @@ dependencies = [
 
 [[package]]
 name = "fog-ocall-oram-storage-trusted"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "aes-ctr",
  "aligned-cmov",
@@ -1570,7 +1570,7 @@ dependencies = [
 
 [[package]]
 name = "fog-ocall-oram-storage-untrusted"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "lazy_static",
  "mc-common",
@@ -1578,7 +1578,7 @@ dependencies = [
 
 [[package]]
 name = "fog-recovery-db-iface"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "displaydoc",
  "fog-kex-rng",
@@ -1592,7 +1592,7 @@ dependencies = [
 
 [[package]]
 name = "fog-report-cli"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "binascii",
  "fog-ingest-enclave-measurement",
@@ -1610,7 +1610,7 @@ dependencies = [
 
 [[package]]
 name = "fog-report-server"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "displaydoc",
  "fog-api",
@@ -1644,7 +1644,7 @@ dependencies = [
 
 [[package]]
 name = "fog-sample-paykit"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "cargo-emit",
  "displaydoc",
@@ -1687,7 +1687,7 @@ dependencies = [
 
 [[package]]
 name = "fog-sql-recovery-db"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "chrono",
  "diesel",
@@ -1716,7 +1716,7 @@ dependencies = [
 
 [[package]]
 name = "fog-test-client"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "fog-sample-paykit",
  "mc-common",
@@ -1730,7 +1730,7 @@ dependencies = [
 
 [[package]]
 name = "fog-test-infra"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "curve25519-dalek",
  "digest",
@@ -1762,7 +1762,7 @@ dependencies = [
 
 [[package]]
 name = "fog-types"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "blake2",
  "displaydoc",
@@ -1777,7 +1777,7 @@ dependencies = [
 
 [[package]]
 name = "fog-uri"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "mc-common",
  "mc-util-uri",
@@ -1785,7 +1785,7 @@ dependencies = [
 
 [[package]]
 name = "fog-view-connection"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "fog-api",
  "fog-enclave-connection",
@@ -1802,7 +1802,7 @@ dependencies = [
 
 [[package]]
 name = "fog-view-enclave"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "cargo-emit",
  "criterion",
@@ -1839,7 +1839,7 @@ dependencies = [
 
 [[package]]
 name = "fog-view-enclave-api"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "displaydoc",
  "fog-recovery-db-iface",
@@ -1857,7 +1857,7 @@ dependencies = [
 
 [[package]]
 name = "fog-view-enclave-edl"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "cargo-emit",
  "mc-util-build-script",
@@ -1865,7 +1865,7 @@ dependencies = [
 
 [[package]]
 name = "fog-view-enclave-impl"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "aligned-cmov",
  "fog-recovery-db-iface",
@@ -1887,7 +1887,7 @@ dependencies = [
 
 [[package]]
 name = "fog-view-enclave-measurement"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "cargo-emit",
  "mc-attest-core",
@@ -1899,7 +1899,7 @@ dependencies = [
 
 [[package]]
 name = "fog-view-load-test"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "fog-kex-rng",
  "fog-uri",
@@ -1916,7 +1916,7 @@ dependencies = [
 
 [[package]]
 name = "fog-view-protocol"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "blake2",
  "displaydoc",
@@ -1939,7 +1939,7 @@ dependencies = [
 
 [[package]]
 name = "fog-view-server"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "displaydoc",
  "fog-api",
@@ -2114,7 +2114,7 @@ dependencies = [
 
 [[package]]
 name = "generate_test_foundation_key"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "mc-account-keys",
  "rand 0.8.3",
@@ -2588,7 +2588,7 @@ checksum = "7fc7aa29613bd6a620df431842069224d8bc9011086b1db4c0e0cd47fa03ec9a"
 
 [[package]]
 name = "libmobilecoin"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "aes-gcm",
  "cbindgen",
@@ -2732,7 +2732,7 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "blake2",
  "curve25519-dalek",
@@ -2752,7 +2752,7 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys-slip10"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -2767,7 +2767,7 @@ dependencies = [
 
 [[package]]
 name = "mc-android-bindings"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2802,7 +2802,7 @@ dependencies = [
 
 [[package]]
 name = "mc-api"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "bs58",
  "cargo-emit",
@@ -2823,7 +2823,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-ake"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "aead",
  "cargo-emit",
@@ -2841,7 +2841,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-api"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "aead",
  "cargo-emit",
@@ -2859,7 +2859,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-core"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "binascii",
  "bitflags",
@@ -2892,7 +2892,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-enclave-api"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "displaydoc",
  "mc-attest-ake",
@@ -2904,7 +2904,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-net"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "cfg-if 0.1.10",
  "failure",
@@ -2922,7 +2922,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-trusted"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "failure",
  "mc-attest-core",
@@ -2933,7 +2933,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-untrusted"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "mc-attest-core",
  "mc-sgx-build",
@@ -2942,7 +2942,7 @@ dependencies = [
 
 [[package]]
 name = "mc-common"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "backtrace",
  "binascii",
@@ -2977,7 +2977,7 @@ dependencies = [
 
 [[package]]
 name = "mc-connection"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "aes-gcm",
  "cookie",
@@ -3002,7 +3002,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-api"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "cargo-emit",
  "futures",
@@ -3017,7 +3017,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "cargo-emit",
  "mc-attest-core",
@@ -3041,7 +3041,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-api"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "failure",
  "mc-attest-ake",
@@ -3059,7 +3059,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-edl"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "cargo-emit",
  "mc-util-build-script",
@@ -3067,7 +3067,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-measurement"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "cargo-emit",
  "mc-attest-core",
@@ -3079,7 +3079,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-scp"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "bigint",
  "maplit",
@@ -3097,7 +3097,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-service"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "base64 0.12.3",
  "chrono",
@@ -3142,7 +3142,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ake-enclave"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "aes-gcm",
  "digest",
@@ -3161,7 +3161,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-box"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "aes-gcm",
  "blake2",
@@ -3175,7 +3175,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ct-aead"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "aead",
  "aes-gcm",
@@ -3185,7 +3185,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "cfg-if 0.1.10",
  "curve25519-dalek",
@@ -3198,7 +3198,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-derive"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.2",
@@ -3207,7 +3207,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-signature"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "mc-crypto-digestible",
  "schnorrkel",
@@ -3216,7 +3216,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-hashes"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "blake2",
  "digest",
@@ -3225,7 +3225,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-keys"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "binascii",
  "curve25519-dalek",
@@ -3250,7 +3250,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-message-cipher"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "aes-gcm",
  "failure",
@@ -3263,7 +3263,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-noise"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "aead",
  "aes-gcm",
@@ -3283,7 +3283,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-rand"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "cfg-if 0.1.10",
  "getrandom 0.1.14",
@@ -3294,7 +3294,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-sig"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "mc-crypto-keys",
  "merlin",
@@ -3305,7 +3305,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-x509-test-vectors"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "cargo-emit",
  "mc-crypto-keys",
@@ -3317,7 +3317,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-x509-utils"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "displaydoc",
  "mc-crypto-keys",
@@ -3327,7 +3327,7 @@ dependencies = [
 
 [[package]]
 name = "mc-enclave-boundary"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "mc-common",
  "mc-crypto-rand",
@@ -3338,7 +3338,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-api"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "cargo-emit",
  "futures",
@@ -3354,7 +3354,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-api-test-utils"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "mc-util-serial",
  "prost",
@@ -3363,7 +3363,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-connection"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "displaydoc",
  "grpcio",
@@ -3380,7 +3380,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-validation"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "displaydoc",
  "mc-account-keys",
@@ -3395,7 +3395,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-validation-test-utils"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "mc-account-keys",
  "mc-fog-report-validation",
@@ -3403,7 +3403,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "displaydoc",
  "mc-account-keys",
@@ -3419,7 +3419,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig-authority"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "mc-crypto-keys",
  "signature",
@@ -3427,7 +3427,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig-report"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -3439,7 +3439,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-types"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "mc-attest-core",
  "mc-crypto-digestible",
@@ -3449,7 +3449,7 @@ dependencies = [
 
 [[package]]
 name = "mc-ledger-db"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "curve25519-dalek",
  "failure",
@@ -3470,7 +3470,7 @@ dependencies = [
 
 [[package]]
 name = "mc-ledger-sync"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "crossbeam-channel 0.5.0",
  "failure",
@@ -3498,7 +3498,7 @@ dependencies = [
 
 [[package]]
 name = "mc-mobilecoind"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "aes-gcm",
  "blake2",
@@ -3550,7 +3550,7 @@ dependencies = [
 
 [[package]]
 name = "mc-mobilecoind-api"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "cargo-emit",
  "futures",
@@ -3601,7 +3601,7 @@ dependencies = [
 
 [[package]]
 name = "mc-peers"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "crossbeam-channel 0.5.0",
  "ed25519",
@@ -3630,7 +3630,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-build"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "cc",
  "lazy_static",
@@ -3640,7 +3640,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-compat"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "cfg-if 0.1.10",
  "mc-sgx-types",
@@ -3648,7 +3648,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-css"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "displaydoc",
  "sha2",
@@ -3656,21 +3656,21 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-debug-edl"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-panic-edl"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-report-cache-api"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -3681,7 +3681,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-report-cache-untrusted"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -3696,7 +3696,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "cfg-if 0.1.10",
  "mc-common",
@@ -3706,18 +3706,18 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog-edl"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-types"
-version = "1.1.0-pre4"
+version = "1.1.0"
 
 [[package]]
 name = "mc-sgx-urts"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "mc-common",
  "mc-sgx-build",
@@ -3728,7 +3728,7 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-core"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "blake2",
  "bulletproofs",
@@ -3756,7 +3756,7 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-core-test-utils"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "mc-account-keys",
  "mc-crypto-keys",
@@ -3772,7 +3772,7 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-std"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "blake2",
  "curve25519-dalek",
@@ -3791,7 +3791,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-enclave"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "cargo-emit",
  "cargo_metadata 0.9.1",
@@ -3807,7 +3807,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-grpc"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "mc-util-build-script",
  "protoc-grpcio",
@@ -3815,11 +3815,11 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-info"
-version = "1.1.0-pre4"
+version = "1.1.0"
 
 [[package]]
 name = "mc-util-build-script"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "cargo-emit",
  "failure",
@@ -3830,7 +3830,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-sgx"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "cargo-emit",
  "cc",
@@ -3841,7 +3841,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-encodings"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "base64 0.12.3",
  "binascii",
@@ -3853,18 +3853,18 @@ dependencies = [
 
 [[package]]
 name = "mc-util-ffi"
-version = "1.1.0-pre4"
+version = "1.1.0"
 
 [[package]]
 name = "mc-util-from-random"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "rand_core 0.6.2",
 ]
 
 [[package]]
 name = "mc-util-generate-sample-ledger"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "curve25519-dalek",
  "hex 0.3.2",
@@ -3884,7 +3884,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-grpc"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "base64 0.12.3",
  "cookie",
@@ -3912,11 +3912,11 @@ dependencies = [
 
 [[package]]
 name = "mc-util-host-cert"
-version = "1.1.0-pre4"
+version = "1.1.0"
 
 [[package]]
 name = "mc-util-keyfile"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "hex 0.4.2",
  "mc-account-keys",
@@ -3934,7 +3934,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-lmdb"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "displaydoc",
  "lmdb-rkv",
@@ -3944,7 +3944,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-logger-macros"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "proc-macro2 0.4.30",
  "quote 0.6.13",
@@ -3953,7 +3953,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-metered-channel"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "crossbeam-channel 0.5.0",
  "mc-util-metrics",
@@ -3961,7 +3961,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-metrics"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "chrono",
  "grpcio",
@@ -3974,7 +3974,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-repr-bytes"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "generic-array",
  "prost",
@@ -3983,7 +3983,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-serial"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "prost",
  "serde",
@@ -3992,7 +3992,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-test-helper"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "lazy_static",
  "mc-account-keys",
@@ -4004,7 +4004,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-uri"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "base64 0.12.3",
  "displaydoc",
@@ -4020,7 +4020,7 @@ dependencies = [
 
 [[package]]
 name = "mc-watcher"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "displaydoc",
  "grpcio",
@@ -4053,7 +4053,7 @@ dependencies = [
 
 [[package]]
 name = "mc-watcher-api"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "displaydoc",
  "serde",

--- a/android-bindings/Cargo.toml
+++ b/android-bindings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-android-bindings"
-version = "1.1.0-pre4"
+version = "1.1.0"
 authors = ["MobileCoin"]
 edition = "2018"
 resolver = "2"

--- a/android-bindings/Cargo.toml
+++ b/android-bindings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-android-bindings"
-version = "1.0.0"
+version = "1.1.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 resolver = "2"

--- a/android-bindings/Cargo.toml
+++ b/android-bindings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-android-bindings"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 authors = ["MobileCoin"]
 edition = "2018"
 resolver = "2"

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "benchmarks"
-version = "1.1.0-pre4"
+version = "1.1.0"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "benchmarks"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "benchmarks"
-version = "1.0.0"
+version = "1.1.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/api/Cargo.toml
+++ b/fog/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-api"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/api/Cargo.toml
+++ b/fog/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-api"
-version = "1.0.0"
+version = "1.1.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/api/Cargo.toml
+++ b/fog/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-api"
-version = "1.1.0-pre4"
+version = "1.1.0"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/distribution/Cargo.toml
+++ b/fog/distribution/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-distribution"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/distribution/Cargo.toml
+++ b/fog/distribution/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-distribution"
-version = "1.1.0-pre4"
+version = "1.1.0"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/distribution/Cargo.toml
+++ b/fog/distribution/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-distribution"
-version = "1.0.0"
+version = "1.1.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/enclave_connection/Cargo.toml
+++ b/fog/enclave_connection/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-enclave-connection"
-version = "1.1.0-pre4"
+version = "1.1.0"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/enclave_connection/Cargo.toml
+++ b/fog/enclave_connection/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-enclave-connection"
-version = "1.0.0"
+version = "1.1.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/enclave_connection/Cargo.toml
+++ b/fog/enclave_connection/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-enclave-connection"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/fog_types/Cargo.toml
+++ b/fog/fog_types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-types"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/fog_types/Cargo.toml
+++ b/fog/fog_types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-types"
-version = "1.0.0"
+version = "1.1.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/fog_types/Cargo.toml
+++ b/fog/fog_types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-types"
-version = "1.1.0-pre4"
+version = "1.1.0"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/ingest/client/Cargo.toml
+++ b/fog/ingest/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-ingest-client"
-version = "1.1.0-pre4"
+version = "1.1.0"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/ingest/client/Cargo.toml
+++ b/fog/ingest/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-ingest-client"
-version = "1.0.0"
+version = "1.1.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/ingest/client/Cargo.toml
+++ b/fog/ingest/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-ingest-client"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/ingest/enclave/Cargo.toml
+++ b/fog/ingest/enclave/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-ingest-enclave"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/ingest/enclave/Cargo.toml
+++ b/fog/ingest/enclave/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-ingest-enclave"
-version = "1.0.0"
+version = "1.1.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/ingest/enclave/Cargo.toml
+++ b/fog/ingest/enclave/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-ingest-enclave"
-version = "1.1.0-pre4"
+version = "1.1.0"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/ingest/enclave/api/Cargo.toml
+++ b/fog/ingest/enclave/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-ingest-enclave-api"
-version = "1.0.0"
+version = "1.1.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/ingest/enclave/api/Cargo.toml
+++ b/fog/ingest/enclave/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-ingest-enclave-api"
-version = "1.1.0-pre4"
+version = "1.1.0"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/ingest/enclave/api/Cargo.toml
+++ b/fog/ingest/enclave/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-ingest-enclave-api"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/ingest/enclave/edl/Cargo.toml
+++ b/fog/ingest/enclave/edl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-ingest-enclave-edl"
-version = "1.0.0"
+version = "1.1.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 links = "ingest_enclave_edl"

--- a/fog/ingest/enclave/edl/Cargo.toml
+++ b/fog/ingest/enclave/edl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-ingest-enclave-edl"
-version = "1.1.0-pre4"
+version = "1.1.0"
 authors = ["MobileCoin"]
 edition = "2018"
 links = "ingest_enclave_edl"

--- a/fog/ingest/enclave/edl/Cargo.toml
+++ b/fog/ingest/enclave/edl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-ingest-enclave-edl"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 authors = ["MobileCoin"]
 edition = "2018"
 links = "ingest_enclave_edl"

--- a/fog/ingest/enclave/impl/Cargo.toml
+++ b/fog/ingest/enclave/impl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-ingest-enclave-impl"
-version = "1.1.0-pre4"
+version = "1.1.0"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/ingest/enclave/impl/Cargo.toml
+++ b/fog/ingest/enclave/impl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-ingest-enclave-impl"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/ingest/enclave/impl/Cargo.toml
+++ b/fog/ingest/enclave/impl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-ingest-enclave-impl"
-version = "1.0.0"
+version = "1.1.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/ingest/enclave/measurement/Cargo.toml
+++ b/fog/ingest/enclave/measurement/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-ingest-enclave-measurement"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 authors = ["MobileCoin"]
 edition = "2018"
 description = "MobileCoin Ingest Enclave - Measurement"

--- a/fog/ingest/enclave/measurement/Cargo.toml
+++ b/fog/ingest/enclave/measurement/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-ingest-enclave-measurement"
-version = "1.1.0-pre4"
+version = "1.1.0"
 authors = ["MobileCoin"]
 edition = "2018"
 description = "MobileCoin Ingest Enclave - Measurement"

--- a/fog/ingest/enclave/measurement/Cargo.toml
+++ b/fog/ingest/enclave/measurement/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-ingest-enclave-measurement"
-version = "1.0.0"
+version = "1.1.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 description = "MobileCoin Ingest Enclave - Measurement"

--- a/fog/ingest/enclave/trusted/Cargo.lock
+++ b/fog/ingest/enclave/trusted/Cargo.lock
@@ -469,7 +469,7 @@ dependencies = [
 
 [[package]]
 name = "fog-ingest-enclave-api"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "displaydoc",
  "fog-kex-rng",
@@ -486,7 +486,7 @@ dependencies = [
 
 [[package]]
 name = "fog-ingest-enclave-edl"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "cargo-emit",
  "mc-util-build-script",
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "fog-ingest-enclave-impl"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "aligned-cmov",
  "fog-ingest-enclave-api",
@@ -523,7 +523,7 @@ dependencies = [
 
 [[package]]
 name = "fog-kex-rng"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "blake2",
  "displaydoc",
@@ -537,14 +537,14 @@ dependencies = [
 
 [[package]]
 name = "fog-ocall-oram-storage-edl"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "fog-ocall-oram-storage-trusted"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "aes-ctr",
  "aligned-cmov",
@@ -560,7 +560,7 @@ dependencies = [
 
 [[package]]
 name = "fog-recovery-db-iface"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "displaydoc",
  "fog-kex-rng",
@@ -574,7 +574,7 @@ dependencies = [
 
 [[package]]
 name = "fog-types"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "blake2",
  "displaydoc",
@@ -713,7 +713,7 @@ dependencies = [
 
 [[package]]
 name = "ingest_enclave_trusted"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "cargo-emit",
  "fog-ingest-enclave-api",
@@ -825,7 +825,7 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "blake2",
  "curve25519-dalek",
@@ -845,7 +845,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-ake"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "aead",
  "cargo-emit",
@@ -863,7 +863,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-core"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "binascii",
  "bitflags",
@@ -896,7 +896,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-enclave-api"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "displaydoc",
  "mc-attest-ake",
@@ -908,7 +908,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-trusted"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "failure",
  "mc-attest-core",
@@ -919,7 +919,7 @@ dependencies = [
 
 [[package]]
 name = "mc-common"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "binascii",
  "cfg-if 0.1.10",
@@ -939,7 +939,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ake-enclave"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "aes-gcm",
  "digest",
@@ -958,7 +958,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-box"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "aes-gcm",
  "blake2",
@@ -972,7 +972,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ct-aead"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "aead",
  "aes-gcm",
@@ -982,7 +982,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "cfg-if 0.1.10",
  "curve25519-dalek",
@@ -995,7 +995,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-derive"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1004,7 +1004,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-signature"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "mc-crypto-digestible",
  "schnorrkel",
@@ -1013,7 +1013,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-hashes"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "blake2",
  "digest",
@@ -1022,7 +1022,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-keys"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "binascii",
  "curve25519-dalek",
@@ -1047,7 +1047,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-noise"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "aead",
  "aes-gcm",
@@ -1067,7 +1067,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-rand"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "cfg-if 0.1.10",
  "getrandom 0.1.13",
@@ -1078,7 +1078,7 @@ dependencies = [
 
 [[package]]
 name = "mc-enclave-boundary"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "mc-common",
  "mc-crypto-rand",
@@ -1089,7 +1089,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig-authority"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "mc-crypto-keys",
  "signature",
@@ -1134,11 +1134,11 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-alloc"
-version = "1.1.0-pre4"
+version = "1.1.0"
 
 [[package]]
 name = "mc-sgx-build"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "cc",
  "lazy_static",
@@ -1148,7 +1148,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-compat"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "cfg-if 0.1.10",
  "mc-sgx-alloc",
@@ -1161,7 +1161,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-css"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "displaydoc",
  "sha2",
@@ -1169,36 +1169,36 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-debug"
-version = "1.1.0-pre4"
+version = "1.1.0"
 
 [[package]]
 name = "mc-sgx-debug-edl"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-enclave-id"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "mc-sgx-types",
 ]
 
 [[package]]
 name = "mc-sgx-panic"
-version = "1.1.0-pre4"
+version = "1.1.0"
 
 [[package]]
 name = "mc-sgx-panic-edl"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-report-cache-api"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -1209,7 +1209,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-service"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "mc-sgx-build",
  "mc-sgx-types",
@@ -1217,7 +1217,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "cfg-if 0.1.10",
  "mc-common",
@@ -1227,14 +1227,14 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog-edl"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-sync"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "mc-sgx-panic",
  "mc-sgx-types",
@@ -1242,11 +1242,11 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-types"
-version = "1.1.0-pre4"
+version = "1.1.0"
 
 [[package]]
 name = "mc-transaction-core"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "blake2",
  "bulletproofs",
@@ -1274,7 +1274,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-script"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "cargo-emit",
  "failure",
@@ -1285,7 +1285,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-sgx"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "cargo-emit",
  "cc",
@@ -1296,7 +1296,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-encodings"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "base64",
  "binascii",
@@ -1308,14 +1308,14 @@ dependencies = [
 
 [[package]]
 name = "mc-util-from-random"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "rand_core",
 ]
 
 [[package]]
 name = "mc-util-repr-bytes"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "generic-array",
  "prost",
@@ -1324,7 +1324,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-serial"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "prost",
  "serde",
@@ -1333,7 +1333,7 @@ dependencies = [
 
 [[package]]
 name = "mc-watcher-api"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "displaydoc",
  "serde",

--- a/fog/ingest/enclave/trusted/Cargo.lock
+++ b/fog/ingest/enclave/trusted/Cargo.lock
@@ -469,7 +469,7 @@ dependencies = [
 
 [[package]]
 name = "fog-ingest-enclave-api"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "displaydoc",
  "fog-kex-rng",
@@ -486,7 +486,7 @@ dependencies = [
 
 [[package]]
 name = "fog-ingest-enclave-edl"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "cargo-emit",
  "mc-util-build-script",
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "fog-ingest-enclave-impl"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "aligned-cmov",
  "fog-ingest-enclave-api",
@@ -523,7 +523,7 @@ dependencies = [
 
 [[package]]
 name = "fog-kex-rng"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "blake2",
  "displaydoc",
@@ -537,14 +537,14 @@ dependencies = [
 
 [[package]]
 name = "fog-ocall-oram-storage-edl"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "fog-ocall-oram-storage-trusted"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "aes-ctr",
  "aligned-cmov",
@@ -560,7 +560,7 @@ dependencies = [
 
 [[package]]
 name = "fog-recovery-db-iface"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "displaydoc",
  "fog-kex-rng",
@@ -574,7 +574,7 @@ dependencies = [
 
 [[package]]
 name = "fog-types"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "blake2",
  "displaydoc",
@@ -713,7 +713,7 @@ dependencies = [
 
 [[package]]
 name = "ingest_enclave_trusted"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "cargo-emit",
  "fog-ingest-enclave-api",
@@ -825,7 +825,7 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "blake2",
  "curve25519-dalek",
@@ -845,7 +845,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-ake"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "aead",
  "cargo-emit",
@@ -863,7 +863,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-core"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "binascii",
  "bitflags",
@@ -896,7 +896,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-enclave-api"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "displaydoc",
  "mc-attest-ake",
@@ -908,7 +908,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-trusted"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "failure",
  "mc-attest-core",
@@ -919,7 +919,7 @@ dependencies = [
 
 [[package]]
 name = "mc-common"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "binascii",
  "cfg-if 0.1.10",
@@ -939,7 +939,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ake-enclave"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "aes-gcm",
  "digest",
@@ -958,7 +958,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-box"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "aes-gcm",
  "blake2",
@@ -972,7 +972,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ct-aead"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "aead",
  "aes-gcm",
@@ -982,7 +982,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "cfg-if 0.1.10",
  "curve25519-dalek",
@@ -995,7 +995,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-derive"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1004,7 +1004,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-signature"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "mc-crypto-digestible",
  "schnorrkel",
@@ -1013,7 +1013,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-hashes"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "blake2",
  "digest",
@@ -1022,7 +1022,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-keys"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "binascii",
  "curve25519-dalek",
@@ -1047,7 +1047,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-noise"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "aead",
  "aes-gcm",
@@ -1067,7 +1067,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-rand"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "cfg-if 0.1.10",
  "getrandom 0.1.13",
@@ -1078,7 +1078,7 @@ dependencies = [
 
 [[package]]
 name = "mc-enclave-boundary"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "mc-common",
  "mc-crypto-rand",
@@ -1089,7 +1089,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig-authority"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "mc-crypto-keys",
  "signature",
@@ -1134,11 +1134,11 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-alloc"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 
 [[package]]
 name = "mc-sgx-build"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "cc",
  "lazy_static",
@@ -1148,7 +1148,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-compat"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "cfg-if 0.1.10",
  "mc-sgx-alloc",
@@ -1161,7 +1161,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-css"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "displaydoc",
  "sha2",
@@ -1169,36 +1169,36 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-debug"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 
 [[package]]
 name = "mc-sgx-debug-edl"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-enclave-id"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "mc-sgx-types",
 ]
 
 [[package]]
 name = "mc-sgx-panic"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 
 [[package]]
 name = "mc-sgx-panic-edl"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-report-cache-api"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -1209,7 +1209,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-service"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "mc-sgx-build",
  "mc-sgx-types",
@@ -1217,7 +1217,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "cfg-if 0.1.10",
  "mc-common",
@@ -1227,14 +1227,14 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog-edl"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-sync"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "mc-sgx-panic",
  "mc-sgx-types",
@@ -1242,11 +1242,11 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-types"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 
 [[package]]
 name = "mc-transaction-core"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "blake2",
  "bulletproofs",
@@ -1274,7 +1274,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-script"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "cargo-emit",
  "failure",
@@ -1285,7 +1285,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-sgx"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "cargo-emit",
  "cc",
@@ -1296,7 +1296,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-encodings"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "base64",
  "binascii",
@@ -1308,14 +1308,14 @@ dependencies = [
 
 [[package]]
 name = "mc-util-from-random"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "rand_core",
 ]
 
 [[package]]
 name = "mc-util-repr-bytes"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "generic-array",
  "prost",
@@ -1324,7 +1324,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-serial"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "prost",
  "serde",
@@ -1333,7 +1333,7 @@ dependencies = [
 
 [[package]]
 name = "mc-watcher-api"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "displaydoc",
  "serde",

--- a/fog/ingest/enclave/trusted/Cargo.lock
+++ b/fog/ingest/enclave/trusted/Cargo.lock
@@ -469,7 +469,7 @@ dependencies = [
 
 [[package]]
 name = "fog-ingest-enclave-api"
-version = "1.0.0"
+version = "1.1.0-pre2"
 dependencies = [
  "displaydoc",
  "fog-kex-rng",
@@ -486,7 +486,7 @@ dependencies = [
 
 [[package]]
 name = "fog-ingest-enclave-edl"
-version = "1.0.0"
+version = "1.1.0-pre2"
 dependencies = [
  "cargo-emit",
  "mc-util-build-script",
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "fog-ingest-enclave-impl"
-version = "1.0.0"
+version = "1.1.0-pre2"
 dependencies = [
  "aligned-cmov",
  "fog-ingest-enclave-api",
@@ -523,7 +523,7 @@ dependencies = [
 
 [[package]]
 name = "fog-kex-rng"
-version = "1.0.0"
+version = "1.1.0-pre2"
 dependencies = [
  "blake2",
  "displaydoc",
@@ -537,14 +537,14 @@ dependencies = [
 
 [[package]]
 name = "fog-ocall-oram-storage-edl"
-version = "0.5.0"
+version = "1.1.0-pre2"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "fog-ocall-oram-storage-trusted"
-version = "0.5.0"
+version = "1.1.0-pre2"
 dependencies = [
  "aes-ctr",
  "aligned-cmov",
@@ -560,7 +560,7 @@ dependencies = [
 
 [[package]]
 name = "fog-recovery-db-iface"
-version = "1.0.0"
+version = "1.1.0-pre2"
 dependencies = [
  "displaydoc",
  "fog-kex-rng",
@@ -574,7 +574,7 @@ dependencies = [
 
 [[package]]
 name = "fog-types"
-version = "1.0.0"
+version = "1.1.0-pre2"
 dependencies = [
  "blake2",
  "displaydoc",
@@ -713,7 +713,7 @@ dependencies = [
 
 [[package]]
 name = "ingest_enclave_trusted"
-version = "1.0.0"
+version = "1.1.0-pre2"
 dependencies = [
  "cargo-emit",
  "fog-ingest-enclave-api",
@@ -825,7 +825,7 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "blake2",
  "curve25519-dalek",
@@ -845,7 +845,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-ake"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "aead",
  "cargo-emit",
@@ -863,7 +863,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-core"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "binascii",
  "bitflags",
@@ -896,7 +896,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-enclave-api"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "displaydoc",
  "mc-attest-ake",
@@ -908,7 +908,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-trusted"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "failure",
  "mc-attest-core",
@@ -919,7 +919,7 @@ dependencies = [
 
 [[package]]
 name = "mc-common"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "binascii",
  "cfg-if 0.1.10",
@@ -939,7 +939,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ake-enclave"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "aes-gcm",
  "digest",
@@ -958,7 +958,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-box"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "aes-gcm",
  "blake2",
@@ -972,7 +972,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ct-aead"
-version = "0.5.0"
+version = "1.1.0-pre2"
 dependencies = [
  "aead",
  "aes-gcm",
@@ -982,7 +982,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "cfg-if 0.1.10",
  "curve25519-dalek",
@@ -995,7 +995,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-derive"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1004,7 +1004,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-signature"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "mc-crypto-digestible",
  "schnorrkel",
@@ -1013,7 +1013,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-hashes"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "blake2",
  "digest",
@@ -1022,7 +1022,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-keys"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "binascii",
  "curve25519-dalek",
@@ -1047,7 +1047,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-noise"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "aead",
  "aes-gcm",
@@ -1067,7 +1067,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-rand"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "cfg-if 0.1.10",
  "getrandom 0.1.13",
@@ -1078,7 +1078,7 @@ dependencies = [
 
 [[package]]
 name = "mc-enclave-boundary"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "mc-common",
  "mc-crypto-rand",
@@ -1089,7 +1089,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig-authority"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "mc-crypto-keys",
  "signature",
@@ -1134,11 +1134,11 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-alloc"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 
 [[package]]
 name = "mc-sgx-build"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "cc",
  "lazy_static",
@@ -1148,7 +1148,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-compat"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "cfg-if 0.1.10",
  "mc-sgx-alloc",
@@ -1161,7 +1161,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-css"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "displaydoc",
  "sha2",
@@ -1169,36 +1169,36 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-debug"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 
 [[package]]
 name = "mc-sgx-debug-edl"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-enclave-id"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "mc-sgx-types",
 ]
 
 [[package]]
 name = "mc-sgx-panic"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 
 [[package]]
 name = "mc-sgx-panic-edl"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-report-cache-api"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -1209,7 +1209,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-service"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "mc-sgx-build",
  "mc-sgx-types",
@@ -1217,7 +1217,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "cfg-if 0.1.10",
  "mc-common",
@@ -1227,14 +1227,14 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog-edl"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-sync"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "mc-sgx-panic",
  "mc-sgx-types",
@@ -1242,11 +1242,11 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-types"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 
 [[package]]
 name = "mc-transaction-core"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "blake2",
  "bulletproofs",
@@ -1274,7 +1274,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-script"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "cargo-emit",
  "failure",
@@ -1285,7 +1285,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-sgx"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "cargo-emit",
  "cc",
@@ -1296,7 +1296,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-encodings"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "base64",
  "binascii",
@@ -1308,14 +1308,14 @@ dependencies = [
 
 [[package]]
 name = "mc-util-from-random"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "rand_core",
 ]
 
 [[package]]
 name = "mc-util-repr-bytes"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "generic-array",
  "prost",
@@ -1324,7 +1324,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-serial"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "prost",
  "serde",
@@ -1333,7 +1333,7 @@ dependencies = [
 
 [[package]]
 name = "mc-watcher-api"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "displaydoc",
  "serde",

--- a/fog/ingest/enclave/trusted/Cargo.toml
+++ b/fog/ingest/enclave/trusted/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ingest_enclave_trusted"
-version = "1.1.0-pre4"
+version = "1.1.0"
 authors = ["MobileCoin"]
 edition = "2018"
 resolver = "2"

--- a/fog/ingest/enclave/trusted/Cargo.toml
+++ b/fog/ingest/enclave/trusted/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ingest_enclave_trusted"
-version = "1.0.0"
+version = "1.1.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 resolver = "2"

--- a/fog/ingest/enclave/trusted/Cargo.toml
+++ b/fog/ingest/enclave/trusted/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ingest_enclave_trusted"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 authors = ["MobileCoin"]
 edition = "2018"
 resolver = "2"

--- a/fog/ingest/server/Cargo.toml
+++ b/fog/ingest/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-ingest-server"
-version = "1.0.0"
+version = "1.1.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/ingest/server/Cargo.toml
+++ b/fog/ingest/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-ingest-server"
-version = "1.1.0-pre4"
+version = "1.1.0"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/ingest/server/Cargo.toml
+++ b/fog/ingest/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-ingest-server"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/kex_rng/Cargo.toml
+++ b/fog/kex_rng/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-kex-rng"
-version = "1.1.0-pre4"
+version = "1.1.0"
 authors = ["Mobilecoin"]
 edition = "2018"
 readme = "README.md"

--- a/fog/kex_rng/Cargo.toml
+++ b/fog/kex_rng/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-kex-rng"
-version = "1.0.0"
+version = "1.1.0-pre2"
 authors = ["Mobilecoin"]
 edition = "2018"
 readme = "README.md"

--- a/fog/kex_rng/Cargo.toml
+++ b/fog/kex_rng/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-kex-rng"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 authors = ["Mobilecoin"]
 edition = "2018"
 readme = "README.md"

--- a/fog/ledger/connection/Cargo.toml
+++ b/fog/ledger/connection/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-ledger-connection"
-version = "1.0.0"
+version = "1.1.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/ledger/connection/Cargo.toml
+++ b/fog/ledger/connection/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-ledger-connection"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/ledger/connection/Cargo.toml
+++ b/fog/ledger/connection/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-ledger-connection"
-version = "1.1.0-pre4"
+version = "1.1.0"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/ledger/enclave/Cargo.toml
+++ b/fog/ledger/enclave/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-ledger-enclave"
-version = "1.0.0"
+version = "1.1.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/ledger/enclave/Cargo.toml
+++ b/fog/ledger/enclave/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-ledger-enclave"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/ledger/enclave/Cargo.toml
+++ b/fog/ledger/enclave/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-ledger-enclave"
-version = "1.1.0-pre4"
+version = "1.1.0"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/ledger/enclave/api/Cargo.toml
+++ b/fog/ledger/enclave/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-ledger-enclave-api"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 authors = ["MobileCoin"]
 edition = "2018"
 description = """

--- a/fog/ledger/enclave/api/Cargo.toml
+++ b/fog/ledger/enclave/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-ledger-enclave-api"
-version = "1.0.0"
+version = "1.1.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 description = """

--- a/fog/ledger/enclave/api/Cargo.toml
+++ b/fog/ledger/enclave/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-ledger-enclave-api"
-version = "1.1.0-pre4"
+version = "1.1.0"
 authors = ["MobileCoin"]
 edition = "2018"
 description = """

--- a/fog/ledger/enclave/edl/Cargo.toml
+++ b/fog/ledger/enclave/edl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-ledger-enclave-edl"
-version = "1.1.0-pre4"
+version = "1.1.0"
 authors = ["MobileCoin"]
 edition = "2018"
 links = "ledger_enclave_edl"

--- a/fog/ledger/enclave/edl/Cargo.toml
+++ b/fog/ledger/enclave/edl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-ledger-enclave-edl"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 authors = ["MobileCoin"]
 edition = "2018"
 links = "ledger_enclave_edl"

--- a/fog/ledger/enclave/edl/Cargo.toml
+++ b/fog/ledger/enclave/edl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-ledger-enclave-edl"
-version = "1.0.0"
+version = "1.1.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 links = "ledger_enclave_edl"

--- a/fog/ledger/enclave/impl/Cargo.toml
+++ b/fog/ledger/enclave/impl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-ledger-enclave-impl"
-version = "1.1.0-pre4"
+version = "1.1.0"
 authors = ["MobileCoin"]
 edition = "2018"
 description = '''

--- a/fog/ledger/enclave/impl/Cargo.toml
+++ b/fog/ledger/enclave/impl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-ledger-enclave-impl"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 authors = ["MobileCoin"]
 edition = "2018"
 description = '''

--- a/fog/ledger/enclave/impl/Cargo.toml
+++ b/fog/ledger/enclave/impl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-ledger-enclave-impl"
-version = "1.0.0"
+version = "1.1.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 description = '''

--- a/fog/ledger/enclave/measurement/Cargo.toml
+++ b/fog/ledger/enclave/measurement/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-ledger-enclave-measurement"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 authors = ["MobileCoin"]
 edition = "2018"
 description = "MobileCoin Ledger Enclave - Measurement"

--- a/fog/ledger/enclave/measurement/Cargo.toml
+++ b/fog/ledger/enclave/measurement/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-ledger-enclave-measurement"
-version = "1.0.0"
+version = "1.1.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 description = "MobileCoin Ledger Enclave - Measurement"

--- a/fog/ledger/enclave/measurement/Cargo.toml
+++ b/fog/ledger/enclave/measurement/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-ledger-enclave-measurement"
-version = "1.1.0-pre4"
+version = "1.1.0"
 authors = ["MobileCoin"]
 edition = "2018"
 description = "MobileCoin Ledger Enclave - Measurement"

--- a/fog/ledger/enclave/trusted/Cargo.lock
+++ b/fog/ledger/enclave/trusted/Cargo.lock
@@ -418,7 +418,7 @@ dependencies = [
 
 [[package]]
 name = "fog-kex-rng"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "blake2",
  "displaydoc",
@@ -432,7 +432,7 @@ dependencies = [
 
 [[package]]
 name = "fog-ledger-enclave-api"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "displaydoc",
  "fog-types",
@@ -450,7 +450,7 @@ dependencies = [
 
 [[package]]
 name = "fog-ledger-enclave-edl"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "cargo-emit",
  "mc-util-build-script",
@@ -458,7 +458,7 @@ dependencies = [
 
 [[package]]
 name = "fog-ledger-enclave-impl"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "fog-ledger-enclave-api",
  "fog-types",
@@ -473,7 +473,7 @@ dependencies = [
 
 [[package]]
 name = "fog-types"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "blake2",
  "displaydoc",
@@ -645,7 +645,7 @@ dependencies = [
 
 [[package]]
 name = "ledger_enclave_trusted"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "cargo-emit",
  "fog-ledger-enclave-api",
@@ -731,7 +731,7 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "blake2",
  "curve25519-dalek",
@@ -751,7 +751,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-ake"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "aead",
  "cargo-emit",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-core"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "binascii",
  "bitflags",
@@ -802,7 +802,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-enclave-api"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "displaydoc",
  "mc-attest-ake",
@@ -814,7 +814,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-trusted"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "failure",
  "mc-attest-core",
@@ -825,7 +825,7 @@ dependencies = [
 
 [[package]]
 name = "mc-common"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "binascii",
  "cfg-if 0.1.10",
@@ -845,7 +845,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ake-enclave"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "aes-gcm",
  "digest",
@@ -864,7 +864,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-box"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "aes-gcm",
  "blake2",
@@ -878,7 +878,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ct-aead"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "aead",
  "aes-gcm",
@@ -888,7 +888,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "cfg-if 0.1.10",
  "curve25519-dalek",
@@ -901,7 +901,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-derive"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -910,7 +910,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-signature"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "mc-crypto-digestible",
  "schnorrkel",
@@ -919,7 +919,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-hashes"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "blake2",
  "digest",
@@ -928,7 +928,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-keys"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "binascii",
  "curve25519-dalek",
@@ -953,7 +953,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-noise"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "aead",
  "aes-gcm",
@@ -973,7 +973,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-rand"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "cfg-if 0.1.10",
  "getrandom 0.1.13",
@@ -984,7 +984,7 @@ dependencies = [
 
 [[package]]
 name = "mc-enclave-boundary"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "mc-common",
  "mc-crypto-rand",
@@ -995,7 +995,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig-authority"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "mc-crypto-keys",
  "signature",
@@ -1003,11 +1003,11 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-alloc"
-version = "1.1.0-pre4"
+version = "1.1.0"
 
 [[package]]
 name = "mc-sgx-build"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "cc",
  "lazy_static",
@@ -1017,7 +1017,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-compat"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "cfg-if 0.1.10",
  "mc-sgx-alloc",
@@ -1030,7 +1030,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-css"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "displaydoc",
  "sha2",
@@ -1038,36 +1038,36 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-debug"
-version = "1.1.0-pre4"
+version = "1.1.0"
 
 [[package]]
 name = "mc-sgx-debug-edl"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-enclave-id"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "mc-sgx-types",
 ]
 
 [[package]]
 name = "mc-sgx-panic"
-version = "1.1.0-pre4"
+version = "1.1.0"
 
 [[package]]
 name = "mc-sgx-panic-edl"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-report-cache-api"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -1078,7 +1078,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-service"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "mc-sgx-build",
  "mc-sgx-types",
@@ -1086,7 +1086,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "cfg-if 0.1.10",
  "mc-common",
@@ -1096,14 +1096,14 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog-edl"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-sync"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "mc-sgx-panic",
  "mc-sgx-types",
@@ -1111,11 +1111,11 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-types"
-version = "1.1.0-pre4"
+version = "1.1.0"
 
 [[package]]
 name = "mc-transaction-core"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "blake2",
  "bulletproofs",
@@ -1143,7 +1143,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-script"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "cargo-emit",
  "failure",
@@ -1154,7 +1154,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-sgx"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "cargo-emit",
  "cc",
@@ -1165,7 +1165,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-encodings"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "base64",
  "binascii",
@@ -1177,14 +1177,14 @@ dependencies = [
 
 [[package]]
 name = "mc-util-from-random"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "rand_core",
 ]
 
 [[package]]
 name = "mc-util-repr-bytes"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "generic-array",
  "prost",
@@ -1193,7 +1193,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-serial"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "prost",
  "serde",
@@ -1202,7 +1202,7 @@ dependencies = [
 
 [[package]]
 name = "mc-watcher-api"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "displaydoc",
  "serde",

--- a/fog/ledger/enclave/trusted/Cargo.lock
+++ b/fog/ledger/enclave/trusted/Cargo.lock
@@ -418,7 +418,7 @@ dependencies = [
 
 [[package]]
 name = "fog-kex-rng"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "blake2",
  "displaydoc",
@@ -432,7 +432,7 @@ dependencies = [
 
 [[package]]
 name = "fog-ledger-enclave-api"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "displaydoc",
  "fog-types",
@@ -450,7 +450,7 @@ dependencies = [
 
 [[package]]
 name = "fog-ledger-enclave-edl"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "cargo-emit",
  "mc-util-build-script",
@@ -458,7 +458,7 @@ dependencies = [
 
 [[package]]
 name = "fog-ledger-enclave-impl"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "fog-ledger-enclave-api",
  "fog-types",
@@ -473,7 +473,7 @@ dependencies = [
 
 [[package]]
 name = "fog-types"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "blake2",
  "displaydoc",
@@ -645,7 +645,7 @@ dependencies = [
 
 [[package]]
 name = "ledger_enclave_trusted"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "cargo-emit",
  "fog-ledger-enclave-api",
@@ -731,7 +731,7 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "blake2",
  "curve25519-dalek",
@@ -751,7 +751,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-ake"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "aead",
  "cargo-emit",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-core"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "binascii",
  "bitflags",
@@ -802,7 +802,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-enclave-api"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "displaydoc",
  "mc-attest-ake",
@@ -814,7 +814,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-trusted"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "failure",
  "mc-attest-core",
@@ -825,7 +825,7 @@ dependencies = [
 
 [[package]]
 name = "mc-common"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "binascii",
  "cfg-if 0.1.10",
@@ -845,7 +845,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ake-enclave"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "aes-gcm",
  "digest",
@@ -864,7 +864,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-box"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "aes-gcm",
  "blake2",
@@ -878,7 +878,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ct-aead"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "aead",
  "aes-gcm",
@@ -888,7 +888,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "cfg-if 0.1.10",
  "curve25519-dalek",
@@ -901,7 +901,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-derive"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -910,7 +910,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-signature"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "mc-crypto-digestible",
  "schnorrkel",
@@ -919,7 +919,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-hashes"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "blake2",
  "digest",
@@ -928,7 +928,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-keys"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "binascii",
  "curve25519-dalek",
@@ -953,7 +953,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-noise"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "aead",
  "aes-gcm",
@@ -973,7 +973,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-rand"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "cfg-if 0.1.10",
  "getrandom 0.1.13",
@@ -984,7 +984,7 @@ dependencies = [
 
 [[package]]
 name = "mc-enclave-boundary"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "mc-common",
  "mc-crypto-rand",
@@ -995,7 +995,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig-authority"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "mc-crypto-keys",
  "signature",
@@ -1003,11 +1003,11 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-alloc"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 
 [[package]]
 name = "mc-sgx-build"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "cc",
  "lazy_static",
@@ -1017,7 +1017,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-compat"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "cfg-if 0.1.10",
  "mc-sgx-alloc",
@@ -1030,7 +1030,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-css"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "displaydoc",
  "sha2",
@@ -1038,36 +1038,36 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-debug"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 
 [[package]]
 name = "mc-sgx-debug-edl"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-enclave-id"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "mc-sgx-types",
 ]
 
 [[package]]
 name = "mc-sgx-panic"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 
 [[package]]
 name = "mc-sgx-panic-edl"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-report-cache-api"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -1078,7 +1078,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-service"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "mc-sgx-build",
  "mc-sgx-types",
@@ -1086,7 +1086,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "cfg-if 0.1.10",
  "mc-common",
@@ -1096,14 +1096,14 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog-edl"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-sync"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "mc-sgx-panic",
  "mc-sgx-types",
@@ -1111,11 +1111,11 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-types"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 
 [[package]]
 name = "mc-transaction-core"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "blake2",
  "bulletproofs",
@@ -1143,7 +1143,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-script"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "cargo-emit",
  "failure",
@@ -1154,7 +1154,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-sgx"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "cargo-emit",
  "cc",
@@ -1165,7 +1165,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-encodings"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "base64",
  "binascii",
@@ -1177,14 +1177,14 @@ dependencies = [
 
 [[package]]
 name = "mc-util-from-random"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "rand_core",
 ]
 
 [[package]]
 name = "mc-util-repr-bytes"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "generic-array",
  "prost",
@@ -1193,7 +1193,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-serial"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "prost",
  "serde",
@@ -1202,7 +1202,7 @@ dependencies = [
 
 [[package]]
 name = "mc-watcher-api"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "displaydoc",
  "serde",

--- a/fog/ledger/enclave/trusted/Cargo.lock
+++ b/fog/ledger/enclave/trusted/Cargo.lock
@@ -418,7 +418,7 @@ dependencies = [
 
 [[package]]
 name = "fog-kex-rng"
-version = "1.0.0"
+version = "1.1.0-pre2"
 dependencies = [
  "blake2",
  "displaydoc",
@@ -432,7 +432,7 @@ dependencies = [
 
 [[package]]
 name = "fog-ledger-enclave-api"
-version = "1.0.0"
+version = "1.1.0-pre2"
 dependencies = [
  "displaydoc",
  "fog-types",
@@ -450,7 +450,7 @@ dependencies = [
 
 [[package]]
 name = "fog-ledger-enclave-edl"
-version = "1.0.0"
+version = "1.1.0-pre2"
 dependencies = [
  "cargo-emit",
  "mc-util-build-script",
@@ -458,7 +458,7 @@ dependencies = [
 
 [[package]]
 name = "fog-ledger-enclave-impl"
-version = "1.0.0"
+version = "1.1.0-pre2"
 dependencies = [
  "fog-ledger-enclave-api",
  "fog-types",
@@ -473,7 +473,7 @@ dependencies = [
 
 [[package]]
 name = "fog-types"
-version = "1.0.0"
+version = "1.1.0-pre2"
 dependencies = [
  "blake2",
  "displaydoc",
@@ -645,7 +645,7 @@ dependencies = [
 
 [[package]]
 name = "ledger_enclave_trusted"
-version = "1.0.0"
+version = "1.1.0-pre2"
 dependencies = [
  "cargo-emit",
  "fog-ledger-enclave-api",
@@ -731,7 +731,7 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "blake2",
  "curve25519-dalek",
@@ -751,7 +751,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-ake"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "aead",
  "cargo-emit",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-core"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "binascii",
  "bitflags",
@@ -802,7 +802,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-enclave-api"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "displaydoc",
  "mc-attest-ake",
@@ -814,7 +814,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-trusted"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "failure",
  "mc-attest-core",
@@ -825,7 +825,7 @@ dependencies = [
 
 [[package]]
 name = "mc-common"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "binascii",
  "cfg-if 0.1.10",
@@ -845,7 +845,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ake-enclave"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "aes-gcm",
  "digest",
@@ -864,7 +864,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-box"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "aes-gcm",
  "blake2",
@@ -878,7 +878,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ct-aead"
-version = "0.5.0"
+version = "1.1.0-pre2"
 dependencies = [
  "aead",
  "aes-gcm",
@@ -888,7 +888,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "cfg-if 0.1.10",
  "curve25519-dalek",
@@ -901,7 +901,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-derive"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -910,7 +910,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-signature"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "mc-crypto-digestible",
  "schnorrkel",
@@ -919,7 +919,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-hashes"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "blake2",
  "digest",
@@ -928,7 +928,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-keys"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "binascii",
  "curve25519-dalek",
@@ -953,7 +953,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-noise"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "aead",
  "aes-gcm",
@@ -973,7 +973,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-rand"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "cfg-if 0.1.10",
  "getrandom 0.1.13",
@@ -984,7 +984,7 @@ dependencies = [
 
 [[package]]
 name = "mc-enclave-boundary"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "mc-common",
  "mc-crypto-rand",
@@ -995,7 +995,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig-authority"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "mc-crypto-keys",
  "signature",
@@ -1003,11 +1003,11 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-alloc"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 
 [[package]]
 name = "mc-sgx-build"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "cc",
  "lazy_static",
@@ -1017,7 +1017,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-compat"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "cfg-if 0.1.10",
  "mc-sgx-alloc",
@@ -1030,7 +1030,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-css"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "displaydoc",
  "sha2",
@@ -1038,36 +1038,36 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-debug"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 
 [[package]]
 name = "mc-sgx-debug-edl"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-enclave-id"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "mc-sgx-types",
 ]
 
 [[package]]
 name = "mc-sgx-panic"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 
 [[package]]
 name = "mc-sgx-panic-edl"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-report-cache-api"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -1078,7 +1078,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-service"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "mc-sgx-build",
  "mc-sgx-types",
@@ -1086,7 +1086,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "cfg-if 0.1.10",
  "mc-common",
@@ -1096,14 +1096,14 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog-edl"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-sync"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "mc-sgx-panic",
  "mc-sgx-types",
@@ -1111,11 +1111,11 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-types"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 
 [[package]]
 name = "mc-transaction-core"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "blake2",
  "bulletproofs",
@@ -1143,7 +1143,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-script"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "cargo-emit",
  "failure",
@@ -1154,7 +1154,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-sgx"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "cargo-emit",
  "cc",
@@ -1165,7 +1165,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-encodings"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "base64",
  "binascii",
@@ -1177,14 +1177,14 @@ dependencies = [
 
 [[package]]
 name = "mc-util-from-random"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "rand_core",
 ]
 
 [[package]]
 name = "mc-util-repr-bytes"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "generic-array",
  "prost",
@@ -1193,7 +1193,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-serial"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "prost",
  "serde",
@@ -1202,7 +1202,7 @@ dependencies = [
 
 [[package]]
 name = "mc-watcher-api"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "displaydoc",
  "serde",

--- a/fog/ledger/enclave/trusted/Cargo.toml
+++ b/fog/ledger/enclave/trusted/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ledger_enclave_trusted"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 authors = ["MobileCoin"]
 edition = "2018"
 resolver = "2"

--- a/fog/ledger/enclave/trusted/Cargo.toml
+++ b/fog/ledger/enclave/trusted/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ledger_enclave_trusted"
-version = "1.1.0-pre4"
+version = "1.1.0"
 authors = ["MobileCoin"]
 edition = "2018"
 resolver = "2"

--- a/fog/ledger/enclave/trusted/Cargo.toml
+++ b/fog/ledger/enclave/trusted/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ledger_enclave_trusted"
-version = "1.0.0"
+version = "1.1.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 resolver = "2"

--- a/fog/ledger/server/Cargo.toml
+++ b/fog/ledger/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-ledger-server"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/ledger/server/Cargo.toml
+++ b/fog/ledger/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-ledger-server"
-version = "1.0.0"
+version = "1.1.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/ledger/server/Cargo.toml
+++ b/fog/ledger/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-ledger-server"
-version = "1.1.0-pre4"
+version = "1.1.0"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/ledger/test_infra/Cargo.toml
+++ b/fog/ledger/test_infra/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-ledger-test-infra"
-version = "1.1.0-pre4"
+version = "1.1.0"
 authors = ["Mobilecoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/ledger/test_infra/Cargo.toml
+++ b/fog/ledger/test_infra/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-ledger-test-infra"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 authors = ["Mobilecoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/ledger/test_infra/Cargo.toml
+++ b/fog/ledger/test_infra/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-ledger-test-infra"
-version = "1.0.0"
+version = "1.1.0-pre2"
 authors = ["Mobilecoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/load_testing/Cargo.toml
+++ b/fog/load_testing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-load-testing"
-version = "1.1.0-pre4"
+version = "1.1.0"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/load_testing/Cargo.toml
+++ b/fog/load_testing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-load-testing"
-version = "1.0.0"
+version = "1.1.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/load_testing/Cargo.toml
+++ b/fog/load_testing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-load-testing"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/ocall_oram_storage/edl/Cargo.toml
+++ b/fog/ocall_oram_storage/edl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-ocall-oram-storage-edl"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 authors = ["MobileCoin"]
 edition = "2018"
 links = "fog_ocall_oram_storage_edl"

--- a/fog/ocall_oram_storage/edl/Cargo.toml
+++ b/fog/ocall_oram_storage/edl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-ocall-oram-storage-edl"
-version = "0.5.0"
+version = "1.1.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 links = "fog_ocall_oram_storage_edl"

--- a/fog/ocall_oram_storage/edl/Cargo.toml
+++ b/fog/ocall_oram_storage/edl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-ocall-oram-storage-edl"
-version = "1.1.0-pre4"
+version = "1.1.0"
 authors = ["MobileCoin"]
 edition = "2018"
 links = "fog_ocall_oram_storage_edl"

--- a/fog/ocall_oram_storage/testing/Cargo.toml
+++ b/fog/ocall_oram_storage/testing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-ocall-oram-storage-testing"
-version = "0.5.0"
+version = "1.1.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/ocall_oram_storage/testing/Cargo.toml
+++ b/fog/ocall_oram_storage/testing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-ocall-oram-storage-testing"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/ocall_oram_storage/testing/Cargo.toml
+++ b/fog/ocall_oram_storage/testing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-ocall-oram-storage-testing"
-version = "1.1.0-pre4"
+version = "1.1.0"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/ocall_oram_storage/trusted/Cargo.toml
+++ b/fog/ocall_oram_storage/trusted/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-ocall-oram-storage-trusted"
-version = "0.5.0"
+version = "1.1.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/ocall_oram_storage/trusted/Cargo.toml
+++ b/fog/ocall_oram_storage/trusted/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-ocall-oram-storage-trusted"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/ocall_oram_storage/trusted/Cargo.toml
+++ b/fog/ocall_oram_storage/trusted/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-ocall-oram-storage-trusted"
-version = "1.1.0-pre4"
+version = "1.1.0"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/ocall_oram_storage/untrusted/Cargo.toml
+++ b/fog/ocall_oram_storage/untrusted/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-ocall-oram-storage-untrusted"
-version = "0.5.0"
+version = "1.1.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/ocall_oram_storage/untrusted/Cargo.toml
+++ b/fog/ocall_oram_storage/untrusted/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-ocall-oram-storage-untrusted"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/ocall_oram_storage/untrusted/Cargo.toml
+++ b/fog/ocall_oram_storage/untrusted/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-ocall-oram-storage-untrusted"
-version = "1.1.0-pre4"
+version = "1.1.0"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/recovery_db_iface/Cargo.toml
+++ b/fog/recovery_db_iface/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-recovery-db-iface"
-version = "1.1.0-pre4"
+version = "1.1.0"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/recovery_db_iface/Cargo.toml
+++ b/fog/recovery_db_iface/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-recovery-db-iface"
-version = "1.0.0"
+version = "1.1.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/recovery_db_iface/Cargo.toml
+++ b/fog/recovery_db_iface/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-recovery-db-iface"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/report/cli/Cargo.toml
+++ b/fog/report/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-report-cli"
-version = "0.9.0"
+version = "1.1.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/report/cli/Cargo.toml
+++ b/fog/report/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-report-cli"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/report/cli/Cargo.toml
+++ b/fog/report/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-report-cli"
-version = "1.1.0-pre4"
+version = "1.1.0"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/report/server/Cargo.toml
+++ b/fog/report/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-report-server"
-version = "1.1.0-pre4"
+version = "1.1.0"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/report/server/Cargo.toml
+++ b/fog/report/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-report-server"
-version = "1.0.0"
+version = "1.1.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/report/server/Cargo.toml
+++ b/fog/report/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-report-server"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/sample-paykit/Cargo.toml
+++ b/fog/sample-paykit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-sample-paykit"
-version = "1.1.0-pre4"
+version = "1.1.0"
 authors = ["MobileCoin"]
 edition = "2018"
 readme = "README.md"

--- a/fog/sample-paykit/Cargo.toml
+++ b/fog/sample-paykit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-sample-paykit"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 authors = ["MobileCoin"]
 edition = "2018"
 readme = "README.md"

--- a/fog/sample-paykit/Cargo.toml
+++ b/fog/sample-paykit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-sample-paykit"
-version = "1.0.0"
+version = "1.1.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 readme = "README.md"

--- a/fog/sql_recovery_db/Cargo.toml
+++ b/fog/sql_recovery_db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-sql-recovery-db"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 authors = ["Mobilecoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/sql_recovery_db/Cargo.toml
+++ b/fog/sql_recovery_db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-sql-recovery-db"
-version = "1.0.0"
+version = "1.1.0-pre2"
 authors = ["Mobilecoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/sql_recovery_db/Cargo.toml
+++ b/fog/sql_recovery_db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-sql-recovery-db"
-version = "1.1.0-pre4"
+version = "1.1.0"
 authors = ["Mobilecoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/test-client/Cargo.toml
+++ b/fog/test-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-test-client"
-version = "1.0.0"
+version = "1.1.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 readme = "README.md"

--- a/fog/test-client/Cargo.toml
+++ b/fog/test-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-test-client"
-version = "1.1.0-pre4"
+version = "1.1.0"
 authors = ["MobileCoin"]
 edition = "2018"
 readme = "README.md"

--- a/fog/test-client/Cargo.toml
+++ b/fog/test-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-test-client"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 authors = ["MobileCoin"]
 edition = "2018"
 readme = "README.md"

--- a/fog/test_infra/Cargo.toml
+++ b/fog/test_infra/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-test-infra"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/test_infra/Cargo.toml
+++ b/fog/test_infra/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-test-infra"
-version = "1.1.0-pre4"
+version = "1.1.0"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/test_infra/Cargo.toml
+++ b/fog/test_infra/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-test-infra"
-version = "1.0.0"
+version = "1.1.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/uri/Cargo.toml
+++ b/fog/uri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-uri"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/uri/Cargo.toml
+++ b/fog/uri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-uri"
-version = "1.1.0-pre4"
+version = "1.1.0"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/uri/Cargo.toml
+++ b/fog/uri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-uri"
-version = "1.0.0"
+version = "1.1.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/view/connection/Cargo.toml
+++ b/fog/view/connection/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-view-connection"
-version = "1.1.0-pre4"
+version = "1.1.0"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/view/connection/Cargo.toml
+++ b/fog/view/connection/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-view-connection"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/view/connection/Cargo.toml
+++ b/fog/view/connection/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-view-connection"
-version = "1.0.0"
+version = "1.1.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/view/enclave/Cargo.toml
+++ b/fog/view/enclave/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-view-enclave"
-version = "1.1.0-pre4"
+version = "1.1.0"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/view/enclave/Cargo.toml
+++ b/fog/view/enclave/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-view-enclave"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/view/enclave/Cargo.toml
+++ b/fog/view/enclave/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-view-enclave"
-version = "1.0.0"
+version = "1.1.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/view/enclave/api/Cargo.toml
+++ b/fog/view/enclave/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-view-enclave-api"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/view/enclave/api/Cargo.toml
+++ b/fog/view/enclave/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-view-enclave-api"
-version = "1.0.0"
+version = "1.1.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/view/enclave/api/Cargo.toml
+++ b/fog/view/enclave/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-view-enclave-api"
-version = "1.1.0-pre4"
+version = "1.1.0"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/view/enclave/edl/Cargo.toml
+++ b/fog/view/enclave/edl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-view-enclave-edl"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 authors = ["MobileCoin"]
 edition = "2018"
 links = "view_enclave_edl"

--- a/fog/view/enclave/edl/Cargo.toml
+++ b/fog/view/enclave/edl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-view-enclave-edl"
-version = "1.1.0-pre4"
+version = "1.1.0"
 authors = ["MobileCoin"]
 edition = "2018"
 links = "view_enclave_edl"

--- a/fog/view/enclave/edl/Cargo.toml
+++ b/fog/view/enclave/edl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-view-enclave-edl"
-version = "1.0.0"
+version = "1.1.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 links = "view_enclave_edl"

--- a/fog/view/enclave/impl/Cargo.toml
+++ b/fog/view/enclave/impl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-view-enclave-impl"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/view/enclave/impl/Cargo.toml
+++ b/fog/view/enclave/impl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-view-enclave-impl"
-version = "1.1.0-pre4"
+version = "1.1.0"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/view/enclave/impl/Cargo.toml
+++ b/fog/view/enclave/impl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-view-enclave-impl"
-version = "1.0.0"
+version = "1.1.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/view/enclave/measurement/Cargo.toml
+++ b/fog/view/enclave/measurement/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-view-enclave-measurement"
-version = "1.1.0-pre4"
+version = "1.1.0"
 authors = ["MobileCoin"]
 edition = "2018"
 description = "MobileCoin Fog View Enclave - Application Code"

--- a/fog/view/enclave/measurement/Cargo.toml
+++ b/fog/view/enclave/measurement/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-view-enclave-measurement"
-version = "1.0.0"
+version = "1.1.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 description = "MobileCoin Fog View Enclave - Application Code"

--- a/fog/view/enclave/measurement/Cargo.toml
+++ b/fog/view/enclave/measurement/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-view-enclave-measurement"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 authors = ["MobileCoin"]
 edition = "2018"
 description = "MobileCoin Fog View Enclave - Application Code"

--- a/fog/view/enclave/trusted/Cargo.lock
+++ b/fog/view/enclave/trusted/Cargo.lock
@@ -470,7 +470,7 @@ dependencies = [
 
 [[package]]
 name = "fog-kex-rng"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "blake2",
  "displaydoc",
@@ -484,14 +484,14 @@ dependencies = [
 
 [[package]]
 name = "fog-ocall-oram-storage-edl"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "fog-ocall-oram-storage-trusted"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "aes-ctr",
  "aligned-cmov",
@@ -507,7 +507,7 @@ dependencies = [
 
 [[package]]
 name = "fog-recovery-db-iface"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "displaydoc",
  "fog-kex-rng",
@@ -521,7 +521,7 @@ dependencies = [
 
 [[package]]
 name = "fog-types"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "blake2",
  "displaydoc",
@@ -535,7 +535,7 @@ dependencies = [
 
 [[package]]
 name = "fog-view-enclave-api"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "displaydoc",
  "fog-recovery-db-iface",
@@ -553,7 +553,7 @@ dependencies = [
 
 [[package]]
 name = "fog-view-enclave-edl"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "cargo-emit",
  "mc-util-build-script",
@@ -561,7 +561,7 @@ dependencies = [
 
 [[package]]
 name = "fog-view-enclave-impl"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "aligned-cmov",
  "fog-recovery-db-iface",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "blake2",
  "curve25519-dalek",
@@ -821,7 +821,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-ake"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "aead",
  "cargo-emit",
@@ -839,7 +839,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-core"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "binascii",
  "bitflags",
@@ -872,7 +872,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-enclave-api"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "displaydoc",
  "mc-attest-ake",
@@ -884,7 +884,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-trusted"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "failure",
  "mc-attest-core",
@@ -895,7 +895,7 @@ dependencies = [
 
 [[package]]
 name = "mc-common"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "binascii",
  "cfg-if 0.1.10",
@@ -915,7 +915,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ake-enclave"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "aes-gcm",
  "digest",
@@ -934,7 +934,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-box"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "aes-gcm",
  "blake2",
@@ -948,7 +948,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ct-aead"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "aead",
  "aes-gcm",
@@ -958,7 +958,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "cfg-if 0.1.10",
  "curve25519-dalek",
@@ -971,7 +971,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-derive"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -980,7 +980,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-signature"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "mc-crypto-digestible",
  "schnorrkel",
@@ -989,7 +989,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-hashes"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "blake2",
  "digest",
@@ -998,7 +998,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-keys"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "binascii",
  "curve25519-dalek",
@@ -1023,7 +1023,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-noise"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "aead",
  "aes-gcm",
@@ -1043,7 +1043,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-rand"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "cfg-if 0.1.10",
  "getrandom 0.1.13",
@@ -1054,7 +1054,7 @@ dependencies = [
 
 [[package]]
 name = "mc-enclave-boundary"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "mc-common",
  "mc-crypto-rand",
@@ -1065,7 +1065,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig-authority"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "mc-crypto-keys",
  "signature",
@@ -1110,11 +1110,11 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-alloc"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 
 [[package]]
 name = "mc-sgx-build"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "cc",
  "lazy_static",
@@ -1124,7 +1124,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-compat"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "cfg-if 0.1.10",
  "mc-sgx-alloc",
@@ -1137,7 +1137,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-compat-edl"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "cargo-emit",
  "mc-sgx-debug-edl",
@@ -1146,7 +1146,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-css"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "displaydoc",
  "sha2",
@@ -1154,36 +1154,36 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-debug"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 
 [[package]]
 name = "mc-sgx-debug-edl"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-enclave-id"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "mc-sgx-types",
 ]
 
 [[package]]
 name = "mc-sgx-panic"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 
 [[package]]
 name = "mc-sgx-panic-edl"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-report-cache-api"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -1194,7 +1194,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-service"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "mc-sgx-build",
  "mc-sgx-types",
@@ -1202,7 +1202,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "cfg-if 0.1.10",
  "mc-common",
@@ -1212,14 +1212,14 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog-edl"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-sync"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "mc-sgx-panic",
  "mc-sgx-types",
@@ -1227,11 +1227,11 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-types"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 
 [[package]]
 name = "mc-transaction-core"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "blake2",
  "bulletproofs",
@@ -1259,7 +1259,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-script"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "cargo-emit",
  "failure",
@@ -1270,7 +1270,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-sgx"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "cargo-emit",
  "cc",
@@ -1281,7 +1281,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-encodings"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "base64",
  "binascii",
@@ -1293,14 +1293,14 @@ dependencies = [
 
 [[package]]
 name = "mc-util-from-random"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "rand_core",
 ]
 
 [[package]]
 name = "mc-util-repr-bytes"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "generic-array",
  "prost",
@@ -1309,7 +1309,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-serial"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "prost",
  "serde",
@@ -1318,7 +1318,7 @@ dependencies = [
 
 [[package]]
 name = "mc-watcher-api"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "displaydoc",
  "serde",
@@ -1843,7 +1843,7 @@ checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
 
 [[package]]
 name = "view_enclave_trusted"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 dependencies = [
  "cargo-emit",
  "fog-ocall-oram-storage-edl",

--- a/fog/view/enclave/trusted/Cargo.lock
+++ b/fog/view/enclave/trusted/Cargo.lock
@@ -470,7 +470,7 @@ dependencies = [
 
 [[package]]
 name = "fog-kex-rng"
-version = "1.0.0"
+version = "1.1.0-pre2"
 dependencies = [
  "blake2",
  "displaydoc",
@@ -484,14 +484,14 @@ dependencies = [
 
 [[package]]
 name = "fog-ocall-oram-storage-edl"
-version = "0.5.0"
+version = "1.1.0-pre2"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "fog-ocall-oram-storage-trusted"
-version = "0.5.0"
+version = "1.1.0-pre2"
 dependencies = [
  "aes-ctr",
  "aligned-cmov",
@@ -507,7 +507,7 @@ dependencies = [
 
 [[package]]
 name = "fog-recovery-db-iface"
-version = "1.0.0"
+version = "1.1.0-pre2"
 dependencies = [
  "displaydoc",
  "fog-kex-rng",
@@ -521,7 +521,7 @@ dependencies = [
 
 [[package]]
 name = "fog-types"
-version = "1.0.0"
+version = "1.1.0-pre2"
 dependencies = [
  "blake2",
  "displaydoc",
@@ -535,7 +535,7 @@ dependencies = [
 
 [[package]]
 name = "fog-view-enclave-api"
-version = "1.0.0"
+version = "1.1.0-pre2"
 dependencies = [
  "displaydoc",
  "fog-recovery-db-iface",
@@ -553,7 +553,7 @@ dependencies = [
 
 [[package]]
 name = "fog-view-enclave-edl"
-version = "1.0.0"
+version = "1.1.0-pre2"
 dependencies = [
  "cargo-emit",
  "mc-util-build-script",
@@ -561,7 +561,7 @@ dependencies = [
 
 [[package]]
 name = "fog-view-enclave-impl"
-version = "1.0.0"
+version = "1.1.0-pre2"
 dependencies = [
  "aligned-cmov",
  "fog-recovery-db-iface",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "blake2",
  "curve25519-dalek",
@@ -821,7 +821,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-ake"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "aead",
  "cargo-emit",
@@ -839,7 +839,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-core"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "binascii",
  "bitflags",
@@ -872,7 +872,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-enclave-api"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "displaydoc",
  "mc-attest-ake",
@@ -884,7 +884,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-trusted"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "failure",
  "mc-attest-core",
@@ -895,7 +895,7 @@ dependencies = [
 
 [[package]]
 name = "mc-common"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "binascii",
  "cfg-if 0.1.10",
@@ -915,7 +915,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ake-enclave"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "aes-gcm",
  "digest",
@@ -934,7 +934,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-box"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "aes-gcm",
  "blake2",
@@ -948,7 +948,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ct-aead"
-version = "0.5.0"
+version = "1.1.0-pre2"
 dependencies = [
  "aead",
  "aes-gcm",
@@ -958,7 +958,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "cfg-if 0.1.10",
  "curve25519-dalek",
@@ -971,7 +971,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-derive"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -980,7 +980,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-signature"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "mc-crypto-digestible",
  "schnorrkel",
@@ -989,7 +989,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-hashes"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "blake2",
  "digest",
@@ -998,7 +998,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-keys"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "binascii",
  "curve25519-dalek",
@@ -1023,7 +1023,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-noise"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "aead",
  "aes-gcm",
@@ -1043,7 +1043,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-rand"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "cfg-if 0.1.10",
  "getrandom 0.1.13",
@@ -1054,7 +1054,7 @@ dependencies = [
 
 [[package]]
 name = "mc-enclave-boundary"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "mc-common",
  "mc-crypto-rand",
@@ -1065,7 +1065,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig-authority"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "mc-crypto-keys",
  "signature",
@@ -1110,11 +1110,11 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-alloc"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 
 [[package]]
 name = "mc-sgx-build"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "cc",
  "lazy_static",
@@ -1124,7 +1124,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-compat"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "cfg-if 0.1.10",
  "mc-sgx-alloc",
@@ -1137,7 +1137,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-compat-edl"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "cargo-emit",
  "mc-sgx-debug-edl",
@@ -1146,7 +1146,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-css"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "displaydoc",
  "sha2",
@@ -1154,36 +1154,36 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-debug"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 
 [[package]]
 name = "mc-sgx-debug-edl"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-enclave-id"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "mc-sgx-types",
 ]
 
 [[package]]
 name = "mc-sgx-panic"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 
 [[package]]
 name = "mc-sgx-panic-edl"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-report-cache-api"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -1194,7 +1194,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-service"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "mc-sgx-build",
  "mc-sgx-types",
@@ -1202,7 +1202,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "cfg-if 0.1.10",
  "mc-common",
@@ -1212,14 +1212,14 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog-edl"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-sync"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "mc-sgx-panic",
  "mc-sgx-types",
@@ -1227,11 +1227,11 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-types"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 
 [[package]]
 name = "mc-transaction-core"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "blake2",
  "bulletproofs",
@@ -1259,7 +1259,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-script"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "cargo-emit",
  "failure",
@@ -1270,7 +1270,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-sgx"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "cargo-emit",
  "cc",
@@ -1281,7 +1281,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-encodings"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "base64",
  "binascii",
@@ -1293,14 +1293,14 @@ dependencies = [
 
 [[package]]
 name = "mc-util-from-random"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "rand_core",
 ]
 
 [[package]]
 name = "mc-util-repr-bytes"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "generic-array",
  "prost",
@@ -1309,7 +1309,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-serial"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "prost",
  "serde",
@@ -1318,7 +1318,7 @@ dependencies = [
 
 [[package]]
 name = "mc-watcher-api"
-version = "1.0.1-pre1"
+version = "1.1.0-pre2"
 dependencies = [
  "displaydoc",
  "serde",
@@ -1843,7 +1843,7 @@ checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
 
 [[package]]
 name = "view_enclave_trusted"
-version = "1.0.0"
+version = "1.1.0-pre2"
 dependencies = [
  "cargo-emit",
  "fog-ocall-oram-storage-edl",

--- a/fog/view/enclave/trusted/Cargo.lock
+++ b/fog/view/enclave/trusted/Cargo.lock
@@ -470,7 +470,7 @@ dependencies = [
 
 [[package]]
 name = "fog-kex-rng"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "blake2",
  "displaydoc",
@@ -484,14 +484,14 @@ dependencies = [
 
 [[package]]
 name = "fog-ocall-oram-storage-edl"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "fog-ocall-oram-storage-trusted"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "aes-ctr",
  "aligned-cmov",
@@ -507,7 +507,7 @@ dependencies = [
 
 [[package]]
 name = "fog-recovery-db-iface"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "displaydoc",
  "fog-kex-rng",
@@ -521,7 +521,7 @@ dependencies = [
 
 [[package]]
 name = "fog-types"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "blake2",
  "displaydoc",
@@ -535,7 +535,7 @@ dependencies = [
 
 [[package]]
 name = "fog-view-enclave-api"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "displaydoc",
  "fog-recovery-db-iface",
@@ -553,7 +553,7 @@ dependencies = [
 
 [[package]]
 name = "fog-view-enclave-edl"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "cargo-emit",
  "mc-util-build-script",
@@ -561,7 +561,7 @@ dependencies = [
 
 [[package]]
 name = "fog-view-enclave-impl"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "aligned-cmov",
  "fog-recovery-db-iface",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "blake2",
  "curve25519-dalek",
@@ -821,7 +821,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-ake"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "aead",
  "cargo-emit",
@@ -839,7 +839,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-core"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "binascii",
  "bitflags",
@@ -872,7 +872,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-enclave-api"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "displaydoc",
  "mc-attest-ake",
@@ -884,7 +884,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-trusted"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "failure",
  "mc-attest-core",
@@ -895,7 +895,7 @@ dependencies = [
 
 [[package]]
 name = "mc-common"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "binascii",
  "cfg-if 0.1.10",
@@ -915,7 +915,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ake-enclave"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "aes-gcm",
  "digest",
@@ -934,7 +934,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-box"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "aes-gcm",
  "blake2",
@@ -948,7 +948,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ct-aead"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "aead",
  "aes-gcm",
@@ -958,7 +958,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "cfg-if 0.1.10",
  "curve25519-dalek",
@@ -971,7 +971,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-derive"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -980,7 +980,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-signature"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "mc-crypto-digestible",
  "schnorrkel",
@@ -989,7 +989,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-hashes"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "blake2",
  "digest",
@@ -998,7 +998,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-keys"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "binascii",
  "curve25519-dalek",
@@ -1023,7 +1023,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-noise"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "aead",
  "aes-gcm",
@@ -1043,7 +1043,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-rand"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "cfg-if 0.1.10",
  "getrandom 0.1.13",
@@ -1054,7 +1054,7 @@ dependencies = [
 
 [[package]]
 name = "mc-enclave-boundary"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "mc-common",
  "mc-crypto-rand",
@@ -1065,7 +1065,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig-authority"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "mc-crypto-keys",
  "signature",
@@ -1110,11 +1110,11 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-alloc"
-version = "1.1.0-pre4"
+version = "1.1.0"
 
 [[package]]
 name = "mc-sgx-build"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "cc",
  "lazy_static",
@@ -1124,7 +1124,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-compat"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "cfg-if 0.1.10",
  "mc-sgx-alloc",
@@ -1137,7 +1137,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-compat-edl"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "cargo-emit",
  "mc-sgx-debug-edl",
@@ -1146,7 +1146,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-css"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "displaydoc",
  "sha2",
@@ -1154,36 +1154,36 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-debug"
-version = "1.1.0-pre4"
+version = "1.1.0"
 
 [[package]]
 name = "mc-sgx-debug-edl"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-enclave-id"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "mc-sgx-types",
 ]
 
 [[package]]
 name = "mc-sgx-panic"
-version = "1.1.0-pre4"
+version = "1.1.0"
 
 [[package]]
 name = "mc-sgx-panic-edl"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-report-cache-api"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -1194,7 +1194,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-service"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "mc-sgx-build",
  "mc-sgx-types",
@@ -1202,7 +1202,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "cfg-if 0.1.10",
  "mc-common",
@@ -1212,14 +1212,14 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog-edl"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-sync"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "mc-sgx-panic",
  "mc-sgx-types",
@@ -1227,11 +1227,11 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-types"
-version = "1.1.0-pre4"
+version = "1.1.0"
 
 [[package]]
 name = "mc-transaction-core"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "blake2",
  "bulletproofs",
@@ -1259,7 +1259,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-script"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "cargo-emit",
  "failure",
@@ -1270,7 +1270,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-sgx"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "cargo-emit",
  "cc",
@@ -1281,7 +1281,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-encodings"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "base64",
  "binascii",
@@ -1293,14 +1293,14 @@ dependencies = [
 
 [[package]]
 name = "mc-util-from-random"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "rand_core",
 ]
 
 [[package]]
 name = "mc-util-repr-bytes"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "generic-array",
  "prost",
@@ -1309,7 +1309,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-serial"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "prost",
  "serde",
@@ -1318,7 +1318,7 @@ dependencies = [
 
 [[package]]
 name = "mc-watcher-api"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "displaydoc",
  "serde",
@@ -1843,7 +1843,7 @@ checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
 
 [[package]]
 name = "view_enclave_trusted"
-version = "1.1.0-pre4"
+version = "1.1.0"
 dependencies = [
  "cargo-emit",
  "fog-ocall-oram-storage-edl",

--- a/fog/view/enclave/trusted/Cargo.toml
+++ b/fog/view/enclave/trusted/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "view_enclave_trusted"
-version = "1.0.0"
+version = "1.1.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 description = "The MobileCoin Fog user-facing server's enclave entry point."

--- a/fog/view/enclave/trusted/Cargo.toml
+++ b/fog/view/enclave/trusted/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "view_enclave_trusted"
-version = "1.1.0-pre4"
+version = "1.1.0"
 authors = ["MobileCoin"]
 edition = "2018"
 description = "The MobileCoin Fog user-facing server's enclave entry point."

--- a/fog/view/enclave/trusted/Cargo.toml
+++ b/fog/view/enclave/trusted/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "view_enclave_trusted"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 authors = ["MobileCoin"]
 edition = "2018"
 description = "The MobileCoin Fog user-facing server's enclave entry point."

--- a/fog/view/load-test/Cargo.toml
+++ b/fog/view/load-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-view-load-test"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/view/load-test/Cargo.toml
+++ b/fog/view/load-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-view-load-test"
-version = "0.10.0"
+version = "1.1.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/view/load-test/Cargo.toml
+++ b/fog/view/load-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-view-load-test"
-version = "1.1.0-pre4"
+version = "1.1.0"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/view/protocol/Cargo.toml
+++ b/fog/view/protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-view-protocol"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 authors = ["MobileCoin"]
 edition = "2018"
 readme = "README.md"

--- a/fog/view/protocol/Cargo.toml
+++ b/fog/view/protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-view-protocol"
-version = "1.0.0"
+version = "1.1.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 readme = "README.md"

--- a/fog/view/protocol/Cargo.toml
+++ b/fog/view/protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-view-protocol"
-version = "1.1.0-pre4"
+version = "1.1.0"
 authors = ["MobileCoin"]
 edition = "2018"
 readme = "README.md"

--- a/fog/view/server/Cargo.toml
+++ b/fog/view/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-view-server"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/view/server/Cargo.toml
+++ b/fog/view/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-view-server"
-version = "1.1.0-pre4"
+version = "1.1.0"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/view/server/Cargo.toml
+++ b/fog/view/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fog-view-server"
-version = "1.0.0"
+version = "1.1.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/generate_test_foundation_key/Cargo.toml
+++ b/generate_test_foundation_key/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "generate_test_foundation_key"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/generate_test_foundation_key/Cargo.toml
+++ b/generate_test_foundation_key/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "generate_test_foundation_key"
-version = "1.0.0"
+version = "1.1.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/generate_test_foundation_key/Cargo.toml
+++ b/generate_test_foundation_key/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "generate_test_foundation_key"
-version = "1.1.0-pre4"
+version = "1.1.0"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/libmobilecoin/Cargo.toml
+++ b/libmobilecoin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libmobilecoin"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/libmobilecoin/Cargo.toml
+++ b/libmobilecoin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libmobilecoin"
-version = "1.1.0-pre4"
+version = "1.1.0"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/libmobilecoin/Cargo.toml
+++ b/libmobilecoin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libmobilecoin"
-version = "1.0.0"
+version = "1.1.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/util/ffi/Cargo.toml
+++ b/util/ffi/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
 name = "mc-util-ffi"
-version = "1.1.0-pre2"
+version = "1.1.0-pre4"
 authors = ["MobileCoin"]
 edition = "2018"

--- a/util/ffi/Cargo.toml
+++ b/util/ffi/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
 name = "mc-util-ffi"
-version = "1.0.0"
+version = "1.1.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"

--- a/util/ffi/Cargo.toml
+++ b/util/ffi/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
 name = "mc-util-ffi"
-version = "1.1.0-pre4"
+version = "1.1.0"
 authors = ["MobileCoin"]
 edition = "2018"


### PR DESCRIPTION
### Motivation

We want to release 1.1.0

### In this PR
* Bump crate versions to 1.1.0
* Update mobilecoin submodule to tip of `1.1.0-version-bump`
* Update changelog
