### PR TITLE
Add go package option to some fog protos

### DIFF
--- a/fog/api/proto/fog_common.proto
+++ b/fog/api/proto/fog_common.proto
@@ -3,6 +3,7 @@
 syntax = "proto3";
 
 package fog_common;
+option go_package = "mobilecoin/api";
 
 /// Represents a half-open range [start_block, end_block) of blocks
 message BlockRange {

--- a/fog/api/proto/kex_rng.proto
+++ b/fog/api/proto/kex_rng.proto
@@ -3,6 +3,7 @@
 syntax = "proto3";
 
 package kex_rng;
+option go_package = "mobilecoin/api";
 
 /// The key exchange message associated to creating a kex rng
 message KexRngPubkey {

--- a/fog/api/proto/ledger.proto
+++ b/fog/api/proto/ledger.proto
@@ -6,6 +6,7 @@ import "external.proto";
 import "fog_common.proto";
 
 package fog_ledger;
+option go_package = "mobilecoin/api";
 
 ////
 // Merkle proofs

--- a/fog/api/proto/view.proto
+++ b/fog/api/proto/view.proto
@@ -3,6 +3,7 @@
 syntax = "proto3";
 
 package fog_view;
+option go_package = "mobilecoin/api";
 
 import "attest.proto";
 import "external.proto";


### PR DESCRIPTION
This is related to grpc bridge project (to allow clients to use HTTP to talk to fog instead of grpc)