### PR TITLE
Fix MacOS CI builder brew error

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -227,6 +227,7 @@ commands:
       - run:
           name: Install Homebrew dependencies
           command: |
+            rm "/usr/local/lib/python3.8/site-packages/six.py"
             brew bundle --no-upgrade
 
   save-homebrew-cache:


### PR DESCRIPTION
### Motivation

The CI build fails with a dependency installation error.

### In this PR
