### PR TITLE
Adjust fog ledger proto

### DIFF
--- a/fog/api/proto/ledger.proto
+++ b/fog/api/proto/ledger.proto
@@ -171,14 +171,14 @@ message BlockRequest {
 
 message BlockResponse {
     /// The block data returned by the server
-    repeated Block blocks = 1;
+    repeated BlockData blocks = 1;
     /// The total number of blocks in the ledger at the time the request is evaluated
     uint64 num_blocks = 2;
     /// The total number of Txos in the ledger at the time the request is evaluated
     uint64 global_txo_count = 3;
 }
 
-message Block {
+message BlockData {
     /// The index of the block in the blockchain
     uint64 index = 1;
     /// The cumulative number of Txos in the blockchain, including this block

--- a/fog/ledger/server/src/block_service.rs
+++ b/fog/ledger/server/src/block_service.rs
@@ -2,7 +2,7 @@
 
 use fog_api::{
     external,
-    ledger::{Block, BlockRequest, BlockResponse},
+    ledger::{BlockData, BlockRequest, BlockResponse},
     ledger_grpc::FogBlockApi,
 };
 use grpcio::{RpcContext, RpcStatus, UnarySink};
@@ -66,8 +66,8 @@ impl<L: Ledger + Clone> BlockService<L> {
         Ok(result)
     }
 
-    fn get_block(&mut self, block_index: u64) -> Result<Block, DbError> {
-        let mut result = Block::new();
+    fn get_block(&mut self, block_index: u64) -> Result<BlockData, DbError> {
+        let mut result = BlockData::new();
         let block_contents = self.ledger.get_block_contents(block_index)?;
         let block = self.ledger.get_block(block_index)?;
         for output in block_contents.outputs {


### PR DESCRIPTION
The fog ledger proto contains a message called Block, but this
also exists in the blockchain.proto. This causes a naming conflict
when building go bindings for the grpc bridge.

The simplest way to resolve this issue is to rename the fog proto.
In this commit, we rename it to `BlockData` and update the fog ledger
server for this.

This is not a breaking change for clients because renaming a message
doesn't break the protobuf API. When they upgrade to the new proto
version though, they might have to update the names of some generated
structs.