### PR TITLE
Revert "Revert "fog omits compressed commitment from TxOutRecord (#71)" (#75)"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1765,6 +1765,7 @@ name = "fog-types"
 version = "1.1.0"
 dependencies = [
  "blake2",
+ "crc",
  "displaydoc",
  "fog-kex-rng",
  "mc-crypto-keys",

--- a/fog/api/proto/view.proto
+++ b/fog/api/proto/view.proto
@@ -205,20 +205,6 @@ enum TxOutSearchResultCode {
     RateLimited = 5;
 }
 
-
-/// A Redacted Fog Transaction Output.
-/// This is the same as a normal TxOut, except that the fog hint is removed after processing, to save storage.
-message FogTxOut {
-    /// Amount.
-    external.Amount amount = 1;
-
-    /// Public key.
-    external.CompressedRistretto target_key = 2;
-
-    /// Public key.
-    external.CompressedRistretto public_key = 3;
-}
-
 /// The schema for the decrypted TxOutSearchResult ciphertext
 /// This is the information that the Ingest enclave produces for the user about their TxOut
 ///
@@ -232,6 +218,8 @@ message FogTxOut {
 /// and that's the version of the TxOut that you should use when building a transaction.
 message TxOutRecord {
     /// The (compressed ristretto) bytes of commitment associated to amount field in the TxOut that was recovered
+    ///
+    /// Note: This field is omitted in recent versions, because it can be reconstructed by the recipient instead.
     bytes tx_out_amount_commitment_data = 1;
     /// The masked value associated to amount field in the TxOut that was recovered
     fixed64 tx_out_amount_masked_value = 2;
@@ -268,4 +256,10 @@ message TxOutRecord {
     ///
     /// Represented as seconds of UTC time since Unix epoch 1970-01-01T00:00:00Z.
     fixed64 timestamp = 7;
+    /// The crc32 of the commitment data bytes.
+    /// This is a 4-byte IEEE crc32 of the bytes of the tx_out_amount_commitment_data bytes, which is present if
+    /// the full tx_out_amount_commitment_data is omitted.
+    /// The client can recompute the tx_out_amount_commitment from the other data that we include.
+    /// They can confirm correct recomputation by checking this crc value.
+    fixed32 tx_out_amount_commitment_data_crc32 = 8;
 }

--- a/fog/api/tests/fog_types.rs
+++ b/fog/api/tests/fog_types.rs
@@ -198,35 +198,14 @@ fn tx_out_record_round_trip() {
 
     run_with_several_seeds(|mut rng| {
         let fog_txout = fog_types::view::FogTxOut::from(&TxOut::sample(&mut rng));
-
-        let commitment_bytes: &[u8; 32] = fog_txout.amount.commitment.as_ref();
-        let test_val = fog_types::view::TxOutRecord {
-            tx_out_amount_commitment_data: commitment_bytes.to_vec(),
-            tx_out_amount_masked_value: fog_txout.amount.masked_value,
-            tx_out_target_key_data: fog_txout.target_key.as_bytes().to_vec(),
-            tx_out_public_key_data: fog_txout.public_key.as_bytes().to_vec(),
-            tx_out_global_index: rng.next_u64(),
+        let meta = fog_types::view::FogTxOutMetadata {
+            global_index: rng.next_u64(),
             block_index: rng.next_u64(),
-            timestamp: 9,
+            timestamp: rng.next_u64(),
         };
+        let test_val = fog_types::view::TxOutRecord::new(fog_txout, meta);
 
         round_trip_message::<fog_types::view::TxOutRecord, fog_api::view::TxOutRecord>(&test_val);
-    });
-}
-
-/// Test that many random instances of prosty FogTxOut round trip with protobufy
-/// FogTxOut
-#[test]
-fn fog_tx_out_round_trip() {
-    {
-        let test_val: fog_types::view::FogTxOut = Default::default();
-        round_trip_message::<fog_types::view::FogTxOut, fog_api::view::FogTxOut>(&test_val);
-    }
-
-    run_with_several_seeds(|mut rng| {
-        let test_val = fog_types::view::FogTxOut::from(&TxOut::sample(&mut rng));
-
-        round_trip_message::<fog_types::view::FogTxOut, fog_api::view::FogTxOut>(&test_val);
     });
 }
 

--- a/fog/fog_types/Cargo.toml
+++ b/fog/fog_types/Cargo.toml
@@ -12,6 +12,7 @@ mc-watcher-api = { path = "../../mobilecoin/watcher/api" }
 
 fog-kex-rng = { path = "../kex_rng" }
 
+crc = { version = "1.8.1", default-features = false }
 displaydoc = { version = "0.2", default-features = false }
 prost = { version = "0.6.1", default-features = false, features = ["prost-derive"] }
 serde = { version = "1.0", default-features = false, features = ["derive"] }

--- a/fog/ingest/enclave/impl/tests/tx_processing.rs
+++ b/fog/ingest/enclave/impl/tests/tx_processing.rs
@@ -82,7 +82,7 @@ fn test_ingest_enclave(logger: Logger) {
         assert_eq!(tx_rows.len(), 10);
 
         // Check that the tx row ciphertexts have the right size
-        const EXPECTED_PAYLOAD_SIZE: usize = 188; // The observed tx_row.payload size
+        const EXPECTED_PAYLOAD_SIZE: usize = 159; // The observed tx_row.payload size
         for tx_row in tx_rows.iter() {
             assert_eq!(
                 tx_row.payload.len(), EXPECTED_PAYLOAD_SIZE,

--- a/fog/ingest/enclave/trusted/Cargo.lock
+++ b/fog/ingest/enclave/trusted/Cargo.lock
@@ -228,6 +228,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
+name = "build_const"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ae4235e6dac0694637c763029ecea1a2ec9e4e06ec2729bd21ba4d9c863eb7"
+
+[[package]]
 name = "bulletproofs"
 version = "2.0.0"
 source = "git+https://github.com/eranrund/bulletproofs?rev=8a7c9cdd1efafa3ad68cd65676302f925de68373#8a7c9cdd1efafa3ad68cd65676302f925de68373"
@@ -348,6 +354,15 @@ dependencies = [
 name = "cpuid-bool"
 version = "0.1.2"
 source = "git+https://github.com/eranrund/RustCrypto-utils?rev=74f8e04e9d18d93fc6d05c72756c236dc88daa19#74f8e04e9d18d93fc6d05c72756c236dc88daa19"
+
+[[package]]
+name = "crc"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d663548de7f5cca343f1e0a48d14dcfb0e9eb4e079ec58883b7251539fa10aeb"
+dependencies = [
+ "build_const",
+]
 
 [[package]]
 name = "crypto-mac"
@@ -577,6 +592,7 @@ name = "fog-types"
 version = "1.1.0"
 dependencies = [
  "blake2",
+ "crc",
  "displaydoc",
  "fog-kex-rng",
  "mc-crypto-keys",

--- a/fog/ledger/enclave/trusted/Cargo.lock
+++ b/fog/ledger/enclave/trusted/Cargo.lock
@@ -186,6 +186,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
+name = "build_const"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ae4235e6dac0694637c763029ecea1a2ec9e4e06ec2729bd21ba4d9c863eb7"
+
+[[package]]
 name = "bulletproofs"
 version = "2.0.0"
 source = "git+https://github.com/eranrund/bulletproofs?rev=8a7c9cdd1efafa3ad68cd65676302f925de68373#8a7c9cdd1efafa3ad68cd65676302f925de68373"
@@ -306,6 +312,15 @@ dependencies = [
 name = "cpuid-bool"
 version = "0.1.2"
 source = "git+https://github.com/eranrund/RustCrypto-utils?rev=74f8e04e9d18d93fc6d05c72756c236dc88daa19#74f8e04e9d18d93fc6d05c72756c236dc88daa19"
+
+[[package]]
+name = "crc"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d663548de7f5cca343f1e0a48d14dcfb0e9eb4e079ec58883b7251539fa10aeb"
+dependencies = [
+ "build_const",
+]
 
 [[package]]
 name = "crypto-mac"
@@ -476,6 +491,7 @@ name = "fog-types"
 version = "1.1.0"
 dependencies = [
  "blake2",
+ "crc",
  "displaydoc",
  "fog-kex-rng",
  "mc-crypto-keys",

--- a/fog/sample-paykit/src/cached_tx_data/mod.rs
+++ b/fog/sample-paykit/src/cached_tx_data/mod.rs
@@ -582,7 +582,10 @@ impl OwnedTxOut {
     // so we need to backport that into the rust sample paykit.
     pub fn new(rec: TxOutRecord, account_key: &AccountKey) -> StdResult<Self, TxOutMatchingError> {
         // Reconstitute FogTxOut from the "flattened" data in TxOutRecord
-        let tx_out = rec.get_fog_tx_out()?;
+        let fog_tx_out = rec.get_fog_tx_out()?;
+
+        // Reconstute TxOut from FogTxOut and our view private key
+        let tx_out = fog_tx_out.try_recover_tx_out(&account_key.view_private_key())?;
 
         // This is view key scanning part, getting the value fails if view-key scanning
         // fails
@@ -606,7 +609,7 @@ impl OwnedTxOut {
         Ok(Self {
             global_index: rec.tx_out_global_index,
             block_index: rec.block_index,
-            tx_out: TxOut::from(&tx_out),
+            tx_out,
             key_image,
             value,
             status,

--- a/fog/sample-paykit/src/client.rs
+++ b/fog/sample-paykit/src/client.rs
@@ -635,7 +635,7 @@ fn build_transaction_helper<T: RngCore + CryptoRng, FPR: FogPubkeyResolver>(
 mod test_build_transaction_helper {
     use super::*;
     use core::result::Result as StdResult;
-    use fog_types::view::TxOutRecord;
+    use fog_types::view::{FogTxOut, FogTxOutMetadata, TxOutRecord};
     use mc_account_keys::{AccountKey, PublicAddress};
     use mc_common::logger::{test_with_logger, Logger};
     use mc_fog_report_validation::{FogPubkeyError, FullyValidatedFogPubkey};
@@ -683,17 +683,9 @@ mod test_build_transaction_helper {
             let cached_inputs: Vec<(OwnedTxOut, TxOutMembershipProof)> = outputs
                 .into_iter()
                 .map(|tx_out| {
-                    let commitment_bytes: &[u8; 32] = tx_out.amount.commitment.as_ref();
-
-                    let txo_record = TxOutRecord {
-                        tx_out_amount_commitment_data: commitment_bytes.to_vec(),
-                        tx_out_amount_masked_value: tx_out.amount.masked_value,
-                        tx_out_target_key_data: tx_out.target_key.as_bytes().to_vec(),
-                        tx_out_public_key_data: tx_out.public_key.as_bytes().to_vec(),
-                        block_index: 0,
-                        tx_out_global_index: 0,
-                        timestamp: Default::default(),
-                    };
+                    let fog_tx_out = FogTxOut::from(&tx_out);
+                    let meta = FogTxOutMetadata::default();
+                    let txo_record = TxOutRecord::new(fog_tx_out, meta);
 
                     let owned_tx_out = OwnedTxOut::new(txo_record, &sender_account_key).unwrap();
 

--- a/fog/sample-paykit/src/error.rs
+++ b/fog/sample-paykit/src/error.rs
@@ -5,6 +5,7 @@
 use displaydoc::Display;
 use fog_enclave_connection::Error as EnclaveConnectionError;
 use fog_ledger_connection::{Error as LedgerConnectionError, KeyImageQueryError};
+use fog_types::view::FogTxOutError;
 use fog_view_protocol::TxOutPollingError;
 use mc_connection::Error as ConnectionError;
 use mc_consensus_api::ConversionError;
@@ -28,6 +29,9 @@ pub enum TxOutMatchingError {
 
     /// Error parsing key: {0}
     Key(KeyError),
+
+    /// Error decompressing FogTxOut: {0}
+    FogTxOut(FogTxOutError),
 }
 
 impl From<AmountError> for TxOutMatchingError {
@@ -39,6 +43,12 @@ impl From<AmountError> for TxOutMatchingError {
 impl From<KeyError> for TxOutMatchingError {
     fn from(src: KeyError) -> Self {
         Self::Key(src)
+    }
+}
+
+impl From<FogTxOutError> for TxOutMatchingError {
+    fn from(src: FogTxOutError) -> Self {
+        Self::FogTxOut(src)
     }
 }
 

--- a/fog/test_infra/src/mock_users.rs
+++ b/fog/test_infra/src/mock_users.rs
@@ -4,7 +4,10 @@
 //! node, and then exercise the view node to try to find them.
 //! This is basically mocking both the consensus output and the SDK
 
-use fog_types::{view::TxOutRecord, BlockCount};
+use fog_types::{
+    view::{FogTxOut, FogTxOutMetadata, TxOutRecord},
+    BlockCount,
+};
 use fog_view_protocol::{FogViewConnection, UserPrivate, UserRngSet};
 use mc_common::logger::global_log;
 use mc_crypto_keys::RistrettoPublic;
@@ -72,17 +75,15 @@ pub fn test_block_to_inputs_and_expected_outputs(
             .entry(upriv.clone())
             .or_insert_with(HashSet::default);
 
-        let commitment_bytes: &[u8; 32] = txo.amount.commitment.as_ref();
-
-        user_result_set.insert(TxOutRecord {
-            tx_out_amount_commitment_data: commitment_bytes.to_vec(),
-            tx_out_amount_masked_value: txo.amount.masked_value,
-            tx_out_target_key_data: txo.target_key.as_bytes().to_vec(),
-            tx_out_public_key_data: txo.public_key.as_bytes().to_vec(),
-            tx_out_global_index: global_tx_out_index as u64,
+        let fog_tx_out = FogTxOut::from(txo);
+        let meta = FogTxOutMetadata {
+            global_index: global_tx_out_index as u64,
             block_index,
             timestamp,
-        });
+        };
+        let tx_out_record = TxOutRecord::new(fog_tx_out, meta);
+
+        user_result_set.insert(tx_out_record);
         global_tx_out_index += 1;
     }
 

--- a/fog/view/enclave/trusted/Cargo.lock
+++ b/fog/view/enclave/trusted/Cargo.lock
@@ -229,6 +229,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
+name = "build_const"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ae4235e6dac0694637c763029ecea1a2ec9e4e06ec2729bd21ba4d9c863eb7"
+
+[[package]]
 name = "bulletproofs"
 version = "2.0.0"
 source = "git+https://github.com/eranrund/bulletproofs?rev=8a7c9cdd1efafa3ad68cd65676302f925de68373#8a7c9cdd1efafa3ad68cd65676302f925de68373"
@@ -349,6 +355,15 @@ dependencies = [
 name = "cpuid-bool"
 version = "0.1.2"
 source = "git+https://github.com/eranrund/RustCrypto-utils?rev=74f8e04e9d18d93fc6d05c72756c236dc88daa19#74f8e04e9d18d93fc6d05c72756c236dc88daa19"
+
+[[package]]
+name = "crc"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d663548de7f5cca343f1e0a48d14dcfb0e9eb4e079ec58883b7251539fa10aeb"
+dependencies = [
+ "build_const",
+]
 
 [[package]]
 name = "crypto-mac"
@@ -524,6 +539,7 @@ name = "fog-types"
 version = "1.1.0"
 dependencies = [
  "blake2",
+ "crc",
  "displaydoc",
  "fog-kex-rng",
  "mc-crypto-keys",

--- a/fog/view/protocol/src/user_private.rs
+++ b/fog/view/protocol/src/user_private.rs
@@ -108,7 +108,7 @@ impl From<&AccountKey> for UserPrivate {
 mod testing {
     use super::*;
     use core::convert::TryFrom;
-    use fog_types::view::FogTxOut;
+    use fog_types::view::{FogTxOut, FogTxOutMetadata};
     use mc_crypto_box::{CryptoBox, VersionedCryptoBox};
     use mc_crypto_keys::CompressedRistrettoPublic;
     use mc_transaction_core::{fog_hint::FogHint, tx::TxOut};
@@ -161,16 +161,12 @@ mod testing {
 
         // Prep for DB record
         let fog_txout = FogTxOut::from(&txo);
-        let commitment_bytes: &[u8; 32] = fog_txout.amount.commitment.as_ref();
-        let txo_record = TxOutRecord {
-            tx_out_amount_commitment_data: commitment_bytes.to_vec(),
-            tx_out_amount_masked_value: fog_txout.amount.masked_value,
-            tx_out_target_key_data: fog_txout.target_key.as_bytes().to_vec(),
-            tx_out_public_key_data: fog_txout.public_key.as_bytes().to_vec(),
-            tx_out_global_index: 1,
+        let meta = FogTxOutMetadata {
+            global_index: 1,
             block_index: 1,
             timestamp: 42,
         };
+        let txo_record = TxOutRecord::new(fog_txout, meta);
 
         let protobuf = mc_util_serial::encode(&txo_record);
 


### PR DESCRIPTION
This reverts commit 8b97079.

This re-applies that commit after the release branch has been created
and we have agreed to release this commit in the next release

Note that this is a breaking change for the SDKs