### PR TITLE
fix fog view attest error status code

### DIFF
--- a/fog/view/server/src/fog_view_service.rs
+++ b/fog/view/server/src/fog_view_service.rs
@@ -106,11 +106,15 @@ impl<E: ViewEnclaveProxy, DB: RecoveryDb + Send + Sync> FogViewService<E, DB> {
 
     // Helper function that is common
     fn enclave_err_to_rpc_status(&self, context: &str, src: ViewEnclaveError) -> RpcStatus {
-        // Treat prost-decode error as an invalid arg, everything else is an internal
-        // error
+        // Treat prost-decode error as an invalid arg,
+        // treat attest error as permission denied,
+        // everything else is an internal error
         match src {
             ViewEnclaveError::ProstDecode => {
                 rpc_invalid_arg_error(context, "Prost decode failed", &self.logger)
+            }
+            ViewEnclaveError::AttestEnclave(err) => {
+                rpc_permissions_error(context, err, &self.logger)
             }
             other => rpc_internal_error(context, format!("{}", &other), &self.logger),
         }


### PR DESCRIPTION
this is supposed to be "permission denied" so that the clients
can know that they should retry by trying to make a new attested
connection. fog-ledger was already doing this correctly but
it turns out that in this case fog-view wasn't