### PR TITLE
Create android-libs methods that allow android SDK to construct Amount without compressed commitment.

### DIFF
--- a/android-bindings/src/bindings.rs
+++ b/android-bindings/src/bindings.rs
@@ -323,9 +323,9 @@ pub unsafe extern "C" fn Java_com_mobilecoin_lib_Amount_init_1jni_1with_1secret(
             env.get_rust_field(tx_out_shared_secret, RUST_OBJ_FIELD)?;
         let value =
             (masked_value as u64) ^ mc_transaction_core::get_value_mask(&tx_out_shared_secret);
-
         let amount = Amount::new(value, &tx_out_shared_secret);
-        Ok(env.set_rust_field(obj, RUST_OBJ_FIELD, amount)?)
+
+        Ok(env.set_rust_field(obj, RUST_OBJ_FIELD, amount?)?)
     })
 }
 

--- a/android-bindings/src/bindings.rs
+++ b/android-bindings/src/bindings.rs
@@ -323,12 +323,11 @@ pub unsafe extern "C" fn Java_com_mobilecoin_lib_Amount_init_1jni_1with_1secret(
             env.get_rust_field(tx_out_shared_secret, RUST_OBJ_FIELD)?;
         let value =
             (masked_value as u64) ^ mc_transaction_core::get_value_mask(&tx_out_shared_secret);
-        let amount : Amount = Amount::new(value, &tx_out_shared_secret)?;
+        let amount: Amount = Amount::new(value, &tx_out_shared_secret)?;
 
         Ok(env.set_rust_field(obj, RUST_OBJ_FIELD, amount)?)
     })
 }
-
 
 #[no_mangle]
 pub unsafe extern "C" fn Java_com_mobilecoin_lib_Amount_get_1bytes(
@@ -1356,8 +1355,7 @@ pub unsafe extern "C" fn Java_com_mobilecoin_lib_Util_get_1shared_1secret(
             let tx_out_public_key: MutexGuard<RistrettoPublic> =
                 env.get_rust_field(tx_out_public_key, RUST_OBJ_FIELD)?;
 
-            let key = 
-                get_tx_out_shared_secret(&view_private_key, &tx_out_public_key);
+            let key = get_tx_out_shared_secret(&view_private_key, &tx_out_public_key);
 
             let mbox = Box::new(Mutex::new(key));
             let ptr: *mut Mutex<RistrettoPublic> = Box::into_raw(mbox);
@@ -1366,7 +1364,6 @@ pub unsafe extern "C" fn Java_com_mobilecoin_lib_Util_get_1shared_1secret(
         },
     )
 }
-
 
 /********************************************************************
  * Receipt

--- a/android-bindings/src/bindings.rs
+++ b/android-bindings/src/bindings.rs
@@ -323,9 +323,9 @@ pub unsafe extern "C" fn Java_com_mobilecoin_lib_Amount_init_1jni_1with_1secret(
             env.get_rust_field(tx_out_shared_secret, RUST_OBJ_FIELD)?;
         let value =
             (masked_value as u64) ^ mc_transaction_core::get_value_mask(&tx_out_shared_secret);
-        let amount = Amount::new(value, &tx_out_shared_secret);
+        let amount : Amount = Amount::new(value, &tx_out_shared_secret)?;
 
-        Ok(env.set_rust_field(obj, RUST_OBJ_FIELD, amount?)?)
+        Ok(env.set_rust_field(obj, RUST_OBJ_FIELD, amount)?)
     })
 }
 


### PR DESCRIPTION
Soundtrack of this PR: [Why Can't I Touch It? - The Buzzcocks](https://www.youtube.com/watch?v=ed1704QRKh4)

### Motivation
Fog no longer stores a compressed commitment in a TxOutRecord, and the Android SDK  uses this compressed commitment to construct an Amount object. As such, we need to expose android-bindings methods that help the SDK create an Amount object without a compressed commitment.

### In this PR
This PR adds android-bindings methods that help the Android SDK create Amount objects. The "Java_com_mobilecoin_lib_Amount_init_1jni_1with_1secret" is the constructor that creates the Amount object in Rust land, and then the "Java_com_mobilecoin_lib_Amount_get_1bytes" allows the SDK to retrieve the proto bytes for this Rust Amount object. The "Java_com_mobilecoin_lib_Util_get_1shared_1secret" allows the SDK to create a shared secret, which is then used in this new Amount constructor. 

Future Work
- On the Android SDK side, [PR 34](https://github.com/mobilecoinofficial/android-sdk/pull/34) uses these rust bindings to create an Amount object without a compressed commitment.
