### PR TITLE
Add a config option to set fog-view-server omap capacity

### DIFF
--- a/fog/view/server/src/bin/main.rs
+++ b/fog/view/server/src/bin/main.rs
@@ -11,9 +11,6 @@ use mc_util_grpc::AdminServer;
 use std::{env, sync::Arc};
 use structopt::StructOpt;
 
-// FIXME: This should be a config parameter
-const VIEW_OMAP_CAPACITY: u64 = 1024 * 1024;
-
 fn main() {
     mc_common::setup_panic_handler();
     let _sentry_guard = mc_common::sentry::init();
@@ -39,7 +36,7 @@ fn main() {
     let sgx_enclave = SgxViewEnclave::new(
         enclave_path,
         config.client_responder_id.clone(),
-        VIEW_OMAP_CAPACITY,
+        config.omap_capacity,
         logger.clone(),
     );
 

--- a/fog/view/server/src/config.rs
+++ b/fog/view/server/src/config.rs
@@ -45,6 +45,20 @@ pub struct MobileAcctViewConfig {
     /// hours).
     #[structopt(long, default_value = "86400", parse(try_from_str=parse_duration_in_seconds))]
     pub client_auth_token_max_lifetime: Duration,
+
+    /// The capacity to build the OMAP (ORAM hash table) with.
+    /// About 75% of this capacity can be used.
+    /// The hash table will overflow when there are more TxOut's than this,
+    /// and the server will have to be restarted with a larger number.
+    ///
+    /// Note: At time of writing, the hash table will be allocated to use all
+    /// available SGX EPC memory, and then beyond that it will be allocated on
+    /// the heap in the untrusted side. Once the needed capacity exceeds RAM,
+    /// you will either get killed by OOM killer, or it will start being swapped
+    /// to disk by linux kernel. (Unless / until a kernel-bypass pathway is
+    /// developed.)
+    #[structopt(long, default_value = "1048576")]
+    pub omap_capacity: u64,
 }
 
 /// Converts a string containing number of seconds to a Duration object.

--- a/fog/view/server/tests/smoke_tests.rs
+++ b/fog/view/server/tests/smoke_tests.rs
@@ -68,12 +68,13 @@ fn get_test_environment(
             admin_listen_uri: Default::default(),
             client_auth_token_secret: None,
             client_auth_token_max_lifetime: Default::default(),
+            omap_capacity: view_omap_capacity,
         };
 
         let enclave = SgxViewEnclave::new(
             get_enclave_path(fog_view_enclave::ENCLAVE_FILE),
             config.client_responder_id.clone(),
-            view_omap_capacity,
+            config.omap_capacity,
             logger.clone(),
         );
 


### PR DESCRIPTION
Previously this was hard-coded to ~ 1 million, now it defaults to
that, but is configurable.

This addresses an old JIRA ticket