### PR TITLE
fog-report-cli improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1617,6 +1617,7 @@ dependencies = [
 name = "fog-report-cli"
 version = "1.1.0"
 dependencies = [
+ "base64 0.12.3",
  "binascii",
  "fog-ingest-enclave-measurement",
  "grpcio",
@@ -1626,6 +1627,7 @@ dependencies = [
  "mc-crypto-keys",
  "mc-fog-report-connection",
  "mc-fog-report-validation",
+ "mc-sgx-types",
  "mc-util-keyfile",
  "mc-util-uri",
  "structopt",

--- a/fog/report/cli/Cargo.toml
+++ b/fog/report/cli/Cargo.toml
@@ -16,7 +16,9 @@ mc-fog-report-connection = { path = "../../../mobilecoin/fog/report/connection" 
 mc-fog-report-validation = { path = "../../../mobilecoin/fog/report/validation" }
 mc-util-keyfile = { path = "../../../mobilecoin/util/keyfile" }
 mc-util-uri = { path = "../../../mobilecoin/util/uri" }
+mc-sgx-types = { path = "../../../mobilecoin/sgx/types" }
 
+base64 = "0.12"
 binascii = "0.1.4"
 grpcio = "0.9.0"
 structopt = "0.3"

--- a/fog/report/cli/src/main.rs
+++ b/fog/report/cli/src/main.rs
@@ -252,7 +252,12 @@ fn main() {
             &logger,
         );
 
-        get_unvalidated_pubkey(responses, fog_uri, "".to_string(), &logger)
+        get_unvalidated_pubkey(
+            responses,
+            fog_uri,
+            config.fog_report_id.unwrap_or_default(),
+            &logger,
+        )
     };
 
     let mut hex_buf = [0u8; 64];

--- a/fog/report/cli/src/main.rs
+++ b/fog/report/cli/src/main.rs
@@ -202,7 +202,7 @@ fn main() {
             FogUri::from_str(&config.fog_url.clone().expect("no fog url was specified"))
                 .expect("Could not parse fog report url as a valid fog url");
 
-        let report_id = config.fog_report_id.unwrap_or_default();
+        let report_id = config.fog_report_id.clone().unwrap_or_default();
 
         let spki = base64::decode(spki).expect("Couldn't decode spki as base 64");
 

--- a/fog/report/cli/src/main.rs
+++ b/fog/report/cli/src/main.rs
@@ -15,16 +15,18 @@
 
 use binascii::bin2hex;
 use grpcio::EnvBuilder;
-use mc_account_keys::PublicAddress;
-use mc_attest_core::{Verifier, DEBUG_ENCLAVE};
-use mc_common::logger::{create_root_logger, Logger};
-use mc_crypto_keys::CompressedRistrettoPublic;
+use mc_account_keys::{AccountKey, PublicAddress};
+use mc_attest_core::{VerificationReportData, Verifier, DEBUG_ENCLAVE};
+use mc_common::logger::{create_root_logger, log, Logger};
+use mc_crypto_keys::{CompressedRistrettoPublic, RistrettoPublic};
 use mc_fog_report_connection::{Error, GrpcFogReportConnection};
 use mc_fog_report_validation::{
     FogPubkeyResolver, FogReportResponses, FogResolver, FullyValidatedFogPubkey,
 };
+use mc_sgx_types::sgx_report_data_t;
 use mc_util_uri::FogUri;
 use std::{
+    convert::TryFrom,
     path::PathBuf,
     process::exit,
     str::FromStr,
@@ -33,28 +35,66 @@ use std::{
 };
 use structopt::StructOpt;
 
-/// The command-line arguments
+/// A command line utility to reach out to the fog report server and fetch the
+/// ingest report, and optionally validate it.
+///
+/// This command prints the bytes of the ingress pubkey in hex, with no newline,
+/// so that it can be easily captured by automation.
+/// Optionally, it also shows the pubkey-expiry value, in this case the output
+/// is json formatted.
+///
+/// The action can be specified in a few ways:
+/// - Supply a path to a public address file. This will perform full validation,
+///   as if we were sending to this fog user.
+/// - Supply a fog-url and a fog-spki. This will perform full validation, that
+///   would be performed for a fog user with these values in their address.
+/// - Supply only a fog-url. This will perform NO validation, not checking IAS,
+///   measurements, or any cert chains.
 #[derive(Debug, StructOpt)]
 struct Config {
-    /// Path to mobilecoin public address
+    /// Path to mobilecoin public address. Fog url and spki will be extracted,
+    /// and fog signature will be checked.
     #[structopt(long = "public-address", short = "p")]
-    pub public_address: PathBuf,
+    pub public_address: Option<PathBuf>,
+
+    /// The fog url to hit.
+    /// If a public address is supplied, this cannot be supplied.
+    #[structopt(long = "fog-url", short = "u")]
+    pub fog_url: Option<String>,
+
+    /// The fog report id to find.
+    /// This is optional and almost always defaulted to "".
+    /// If a public address is supplied, this cannot be supplied.
+    #[structopt(long = "fog-report-id", short = "i")]
+    pub fog_report_id: Option<String>,
+
+    /// The fog authority spki, in base 64
+    /// If omitted, then NO verification of any kind (IAS, MRSIGNER, cert
+    /// chains) will be performed.
+    /// If a public address is supplied, this cannot be supplied.
+    #[structopt(long = "fog-spki", short = "s")]
+    pub fog_spki: Option<String>,
 
     /// How long to retry if NoReports, this is useful for tests
     #[structopt(long = "retry-seconds", short = "r", default_value = "10")]
     pub retry_seconds: u64,
+
+    /// Indicates to output json encoding of hex bytes of fog ingress pubkey,
+    /// and the pubkey expiry value of this key.
+    #[structopt(long = "show-expiry", short = "v")]
+    pub show_expiry: bool,
 }
 
 /// Get fog response with retries, retrying if NoReports error occurs
 fn get_fog_response_with_retries(
     fog_uri: FogUri,
     retry_duration: Duration,
-    logger: Logger,
+    logger: &Logger,
 ) -> FogReportResponses {
     // Create the grpc object and report verifier
     let grpc_env = Arc::new(EnvBuilder::new().name_prefix("cli").build());
 
-    let conn = GrpcFogReportConnection::new(grpc_env, logger);
+    let conn = GrpcFogReportConnection::new(grpc_env, logger.clone());
 
     let deadline = Instant::now() + retry_duration;
     loop {
@@ -78,20 +118,60 @@ fn get_fog_response_with_retries(
 }
 
 /// Try to resolve a public address to a fog public key
-fn get_pubkey(responses: FogReportResponses, pub_addr: PublicAddress) -> FullyValidatedFogPubkey {
-    let report_verifier = {
+fn get_validated_pubkey(
+    responses: FogReportResponses,
+    pub_addr: PublicAddress,
+    logger: &Logger,
+) -> FullyValidatedFogPubkey {
+    let mut verifier = Verifier::default();
+
+    {
         let mr_signer_verifier = fog_ingest_enclave_measurement::get_mr_signer_verifier(None);
-
-        let mut verifier = Verifier::default();
         verifier.debug(DEBUG_ENCLAVE).mr_signer(mr_signer_verifier);
-        verifier
-    };
+    }
 
-    let resolver = FogResolver::new(responses, &report_verifier);
+    log::debug!(logger, "IAS verifier: {:?}", &verifier);
+
+    let resolver = FogResolver::new(responses, &verifier);
     resolver
-        .expect("Could not get FogPubkeyResolved")
+        .expect("Could not get FogPubkey resolved")
         .get_fog_pubkey(&pub_addr)
         .expect("Could not validate fog pubkey")
+}
+
+/// Try to grab pubkey and expiry out of the response without validating
+fn get_unvalidated_pubkey(
+    responses: FogReportResponses,
+    fog_uri: FogUri,
+    fog_report_id: String,
+    _logger: &Logger,
+) -> (RistrettoPublic, u64) {
+    let resp = responses
+        .get(&fog_uri.to_string())
+        .expect("Didn't find response from this URI");
+    let rep = resp
+        .reports
+        .iter()
+        .find(|rep| rep.fog_report_id == fog_report_id)
+        .expect("Didn't find report with the right report id");
+    let pubkey_expiry = rep.pubkey_expiry;
+    // This parses the b64 json from intel
+    let verification_report_data = VerificationReportData::try_from(&rep.report)
+        .expect("Could not parse verification report data");
+    // This extracts the user-data attached to the report, which is a thin wrapper
+    // around [u8; 64]
+    let report_data = verification_report_data
+        .quote
+        .report_body()
+        .expect("bad report body")
+        .report_data();
+    // Unwrap the wrapper
+    let report_data = sgx_report_data_t::from(report_data);
+    // The second half of this is the data we care about (and which should be
+    // Ristretto)
+    let pubkey = RistrettoPublic::try_from(&report_data.d[32..64])
+        .expect("report didn't contain a valid key");
+    (pubkey, pubkey_expiry)
 }
 
 fn main() {
@@ -100,30 +180,97 @@ fn main() {
     let config = Config::from_args();
     let logger = create_root_logger();
 
-    // Read user public keys from disk
-    let pub_addr = mc_util_keyfile::read_pubfile(config.public_address)
-        .expect("Could not read public address file");
+    // Get public address either from a file, or synthesize from BOTH fog-url and
+    // spki. If we only have fog-url, we can't make a public address and we
+    // won't do any validation.
+    let pub_addr: Option<PublicAddress> = if let Some(path) = config.public_address {
+        let pub_addr =
+            mc_util_keyfile::read_pubfile(path).expect("Could not read public address file");
+        if config.fog_url.is_some() {
+            panic!("Can't specify public address file and fog url");
+        }
+        if config.fog_report_id.is_some() {
+            panic!("Can't specify public address file and fog report id");
+        }
+        if config.fog_spki.is_some() {
+            panic!("Can't specify public address file and fog spki");
+        }
+        Some(pub_addr)
+    } else if let Some(spki) = config.fog_spki {
+        log::debug!(logger, "Creating synthetic public address");
+        let fog_report_url =
+            FogUri::from_str(&config.fog_url.clone().expect("no fog url was specified"))
+                .expect("Could not parse fog report url as a valid fog url");
 
-    // Get fog url
-    let fog_uri = FogUri::from_str(
-        pub_addr
-            .fog_report_url()
-            .expect("public address had no fog url"),
-    )
-    .expect("Could not parse fog report url as a valid fog url");
+        let report_id = config.fog_report_id.unwrap_or_default();
 
-    // Try to make request
-    let responses =
-        get_fog_response_with_retries(fog_uri, Duration::from_secs(config.retry_seconds), logger);
+        let spki = base64::decode(spki).expect("Couldn't decode spki as base 64");
 
-    // Try to validate response
-    let result = get_pubkey(responses, pub_addr);
+        let account_key = AccountKey::new_with_fog(
+            &Default::default(),
+            &Default::default(),
+            fog_report_url,
+            report_id,
+            spki,
+        );
+        Some(account_key.default_subaddress())
+    } else {
+        None
+    };
+
+    // If we got a public address, use the validated code path
+    let (pubkey, pubkey_expiry): (RistrettoPublic, u64) = if let Some(pub_addr) = pub_addr {
+        // Get fog url
+        let fog_uri = FogUri::from_str(
+            pub_addr
+                .fog_report_url()
+                .expect("public address had no fog url"),
+        )
+        .expect("Could not parse fog report url as a valid fog url");
+
+        // Try to make request
+        let responses = get_fog_response_with_retries(
+            fog_uri,
+            Duration::from_secs(config.retry_seconds),
+            &logger,
+        );
+
+        // Try to validate response
+        let result = get_validated_pubkey(responses, pub_addr, &logger);
+        (result.pubkey, result.pubkey_expiry)
+    } else {
+        // In this case, there's no spki and no validation,
+        // we're going to just hit a Fog report server and
+        // parse the pubkey and expiry out of response.
+        let fog_uri = FogUri::from_str(&config.fog_url.expect("no fog url was specified"))
+            .expect("Could not parse fog report url as a valid fog url");
+
+        // Try to make request
+        let responses = get_fog_response_with_retries(
+            fog_uri.clone(),
+            Duration::from_secs(config.retry_seconds),
+            &logger,
+        );
+
+        get_unvalidated_pubkey(responses, fog_uri, "".to_string(), &logger)
+    };
 
     let mut hex_buf = [0u8; 64];
     bin2hex(
-        CompressedRistrettoPublic::from(&result.pubkey).as_ref(),
+        CompressedRistrettoPublic::from(&pubkey).as_ref(),
         &mut hex_buf[..],
     )
     .expect("Failed converting to hex");
-    print!("{}", std::str::from_utf8(&hex_buf).unwrap());
+    let hex_str = std::str::from_utf8(&hex_buf).unwrap();
+
+    // if show-expiry is selected, we show key and expiry, formatted as json
+    // else just print the hex bytes of key
+    if config.show_expiry {
+        print!(
+            "{{ \"pubkey\": \"{}\", \"pubkey_expiry\": {} }}",
+            hex_str, pubkey_expiry
+        );
+    } else {
+        print!("{}", hex_str);
+    }
 }


### PR DESCRIPTION
This makes a second "mode" for fog-report-cli where it doesn't
do any validation of the fog report response and just parses the
data of interest out of it -- that is, the hex bytes of the fog
ingress pubkey, and its pubkey expiry value.

This is useful because sometimes, when the system gets stuck,
the users report "tombstone block exceeded" and it can be traced
back to the pubkey expiry value in the fog report server.

It's also useful because it lets us quickly see the most recent
fog ingress pubkey that has been published. If the active server
dies, knowing the hex bytes of this key may help you figure out
which backup to restart, if they have different keys.

Some pitfalls with this workflow, before this commit:

(1) You had to make a pubkey file which has all the right data,
    which requires going to another repo, building, and running
    a tool to generate keys, and then getting the artifacts to
    this repo and pointing this program at the keyfiles, which
    is cumbersome.
    In the new revision, you can specify fog url and SPKI as
    command-line args and skip the keyfile stuff.
(2) If you don't download all the correct measurements and SPKI's
    for the network, and use that SPKI when you generate sample
    keys, the attestation check or the fog signature check will
    fail and it takes some time to work through this.
    If you are just trying to diagnose why a network is stopped,
    this is kind of a time suck.
    In the new revision, if there is no public address file and
    no spki provided, (only fog url), then we skip the normal
    validation pathway, and use the mc-attest-core types to
    parse the verification report (without validating it) and get
    the data of interest, without any possibility of failure due
    to IAS, attestation, certificate chains, and so on.

Ideally, there would be some kind of dashboard that can provide
this and other information without relying on a cli, but this is
a decent starting point, and may help us diagnose problems later.