### PR TITLE
Use AES256 instead of AES128 in fog ocall oram storage

### DIFF
--- a/fog/ocall_oram_storage/trusted/README.md
+++ b/fog/ocall_oram_storage/trusted/README.md
@@ -16,7 +16,7 @@ The trusted side is required to *encrypt* data blocks that leave, and *authentic
 them when they return.
 
 - Each data block (4096 bytes) comes with a small metadata block (~64 bytes).
-- Both data and metadata are encrypted using AES 128.
+- Both data and metadata are encrypted using AES 256.
 - Each data block holds "extended metadata" including a counter, and the hashes
   of its left and right children.
 - The ciphertexts are hashed (see below for details) together with extended metadata

--- a/fog/ocall_oram_storage/trusted/src/lib.rs
+++ b/fog/ocall_oram_storage/trusted/src/lib.rs
@@ -33,7 +33,7 @@ extern crate alloc;
 
 use alloc::vec;
 
-use aes_ctr::{stream_cipher, Aes128Ctr};
+use aes_ctr::{stream_cipher, Aes256Ctr};
 use aligned_cmov::{typenum, A64Bytes, A8Bytes, ArrayLength, GenericArray};
 use alloc::vec::Vec;
 use balanced_tree_index::TreeIndex;
@@ -98,7 +98,7 @@ lazy_static! {
 
 /// Cipher type. Anything implementing StreamCipher and NewStreamCipher at 128
 /// bit security should be acceptable
-type CipherType = Aes128Ctr;
+type CipherType = Aes256Ctr;
 /// Parameters of the cipher as typedefs (which eases syntax)
 type NonceSize = <CipherType as NewStreamCipher>::NonceSize;
 type KeySize = <CipherType as NewStreamCipher>::KeySize;


### PR DESCRIPTION
Continuing the campaign of AES256 everywhere, for consistency