### PR TITLE
update fog and fog clients for encrypted memo changes: recoverable transaction history

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2786,7 +2786,7 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "blake2",
  "curve25519-dalek",
@@ -2807,7 +2807,7 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys-slip10"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -2857,7 +2857,7 @@ dependencies = [
 
 [[package]]
 name = "mc-api"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "bs58",
  "cargo-emit",
@@ -2878,7 +2878,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-ake"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "aead",
  "cargo-emit",
@@ -2896,7 +2896,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-api"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "aead",
  "cargo-emit",
@@ -2914,7 +2914,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-core"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "binascii",
  "bitflags",
@@ -2946,7 +2946,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-enclave-api"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "displaydoc",
  "mc-attest-ake",
@@ -2958,7 +2958,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-net"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "cfg-if 0.1.10",
  "displaydoc",
@@ -2976,7 +2976,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-trusted"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -2987,7 +2987,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-untrusted"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "mc-attest-core",
  "mc-sgx-build",
@@ -2996,7 +2996,7 @@ dependencies = [
 
 [[package]]
 name = "mc-common"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "backtrace",
  "binascii",
@@ -3031,7 +3031,7 @@ dependencies = [
 
 [[package]]
 name = "mc-connection"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "aes-gcm",
  "cookie",
@@ -3056,7 +3056,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-api"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "cargo-emit",
  "futures",
@@ -3071,7 +3071,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "cargo-emit",
  "mc-attest-core",
@@ -3095,7 +3095,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-api"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "displaydoc",
  "mc-attest-ake",
@@ -3113,7 +3113,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-edl"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "cargo-emit",
  "mc-util-build-script",
@@ -3121,7 +3121,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-measurement"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "cargo-emit",
  "mc-attest-core",
@@ -3133,7 +3133,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-scp"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "bigint",
  "maplit",
@@ -3151,7 +3151,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-service"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "base64 0.12.3",
  "chrono",
@@ -3196,7 +3196,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ake-enclave"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "aes-gcm",
  "digest",
@@ -3215,7 +3215,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-box"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "aead",
  "blake2",
@@ -3229,7 +3229,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "cfg-if 0.1.10",
  "curve25519-dalek",
@@ -3242,7 +3242,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-derive"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.9",
@@ -3251,7 +3251,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-signature"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "mc-crypto-digestible",
  "schnorrkel",
@@ -3260,7 +3260,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-hashes"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "blake2",
  "digest",
@@ -3269,7 +3269,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-keys"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "binascii",
  "curve25519-dalek",
@@ -3294,7 +3294,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-message-cipher"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "aes-gcm",
  "displaydoc",
@@ -3307,7 +3307,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-noise"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "aead",
  "aes-gcm",
@@ -3327,7 +3327,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-rand"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "cfg-if 0.1.10",
  "getrandom 0.1.14",
@@ -3338,7 +3338,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-sig"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "mc-crypto-keys",
  "merlin",
@@ -3349,7 +3349,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-x509-test-vectors"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "cargo-emit",
  "mc-crypto-keys",
@@ -3361,7 +3361,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-x509-utils"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "displaydoc",
  "mc-crypto-keys",
@@ -3371,7 +3371,7 @@ dependencies = [
 
 [[package]]
 name = "mc-enclave-boundary"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "mc-common",
  "mc-crypto-rand",
@@ -3382,7 +3382,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-api"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "cargo-emit",
  "futures",
@@ -3398,7 +3398,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-api-test-utils"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "mc-util-serial",
  "prost",
@@ -3407,7 +3407,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-connection"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "displaydoc",
  "grpcio",
@@ -3424,7 +3424,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-validation"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "displaydoc",
  "mc-account-keys",
@@ -3439,7 +3439,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-validation-test-utils"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "mc-account-keys",
  "mc-fog-report-validation",
@@ -3447,7 +3447,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "displaydoc",
  "mc-account-keys",
@@ -3463,7 +3463,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig-authority"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "mc-crypto-keys",
  "signature",
@@ -3471,7 +3471,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig-report"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -3483,7 +3483,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-types"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "mc-attest-core",
  "mc-crypto-digestible",
@@ -3493,7 +3493,7 @@ dependencies = [
 
 [[package]]
 name = "mc-ledger-db"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -3514,7 +3514,7 @@ dependencies = [
 
 [[package]]
 name = "mc-ledger-sync"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "crossbeam-channel 0.5.0",
  "displaydoc",
@@ -3542,7 +3542,7 @@ dependencies = [
 
 [[package]]
 name = "mc-mobilecoind"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "aes-gcm",
  "blake2",
@@ -3593,7 +3593,7 @@ dependencies = [
 
 [[package]]
 name = "mc-mobilecoind-api"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "cargo-emit",
  "futures",
@@ -3659,7 +3659,7 @@ dependencies = [
 
 [[package]]
 name = "mc-peers"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "crossbeam-channel 0.5.0",
  "displaydoc",
@@ -3688,7 +3688,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-build"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "cc",
  "lazy_static",
@@ -3698,7 +3698,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-compat"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "cfg-if 0.1.10",
  "mc-sgx-types",
@@ -3706,7 +3706,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-css"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "displaydoc",
  "sha2",
@@ -3714,21 +3714,21 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-debug-edl"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-panic-edl"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-report-cache-api"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -3739,7 +3739,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-report-cache-untrusted"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -3754,7 +3754,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "cfg-if 0.1.10",
  "mc-common",
@@ -3764,18 +3764,18 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog-edl"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-types"
-version = "1.1.0"
+version = "1.1.1"
 
 [[package]]
 name = "mc-sgx-urts"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "mc-common",
  "mc-sgx-build",
@@ -3786,7 +3786,7 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-core"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "aes",
  "blake2",
@@ -3817,7 +3817,7 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-core-test-utils"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "mc-account-keys",
  "mc-crypto-keys",
@@ -3833,7 +3833,7 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-std"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "blake2",
  "curve25519-dalek",
@@ -3855,7 +3855,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-enclave"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "cargo-emit",
  "cargo_metadata 0.9.1",
@@ -3871,7 +3871,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-grpc"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "mc-util-build-script",
  "protoc-grpcio",
@@ -3879,11 +3879,11 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-info"
-version = "1.1.0"
+version = "1.1.1"
 
 [[package]]
 name = "mc-util-build-script"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "cargo-emit",
  "displaydoc",
@@ -3894,7 +3894,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-sgx"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "cargo-emit",
  "cc",
@@ -3905,7 +3905,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-encodings"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "base64 0.12.3",
  "binascii",
@@ -3921,14 +3921,14 @@ version = "1.1.0"
 
 [[package]]
 name = "mc-util-from-random"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "rand_core 0.6.2",
 ]
 
 [[package]]
 name = "mc-util-generate-sample-ledger"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "curve25519-dalek",
  "hex 0.3.2",
@@ -3948,7 +3948,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-grpc"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "base64 0.12.3",
  "cookie",
@@ -3976,11 +3976,11 @@ dependencies = [
 
 [[package]]
 name = "mc-util-host-cert"
-version = "1.1.0"
+version = "1.1.1"
 
 [[package]]
 name = "mc-util-keyfile"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "hex 0.4.2",
  "mc-account-keys",
@@ -3998,7 +3998,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-lmdb"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "displaydoc",
  "lmdb-rkv",
@@ -4008,7 +4008,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-logger-macros"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "proc-macro2 0.4.30",
  "quote 0.6.13",
@@ -4017,7 +4017,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-metered-channel"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "crossbeam-channel 0.5.0",
  "mc-util-metrics",
@@ -4025,7 +4025,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-metrics"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "chrono",
  "grpcio",
@@ -4038,7 +4038,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-repr-bytes"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "generic-array",
  "prost",
@@ -4047,7 +4047,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-serial"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "prost",
  "serde",
@@ -4056,7 +4056,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-test-helper"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "lazy_static",
  "mc-account-keys",
@@ -4068,7 +4068,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-uri"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "base64 0.12.3",
  "displaydoc",
@@ -4084,7 +4084,7 @@ dependencies = [
 
 [[package]]
 name = "mc-watcher"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "displaydoc",
  "futures",
@@ -4118,7 +4118,7 @@ dependencies = [
 
 [[package]]
 name = "mc-watcher-api"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "displaydoc",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1757,9 +1757,11 @@ name = "fog-test-client"
 version = "1.1.0"
 dependencies = [
  "fog-sample-paykit",
+ "mc-account-keys",
  "mc-common",
  "mc-crypto-rand",
  "mc-transaction-core",
+ "mc-transaction-std",
  "mc-util-keyfile",
  "mc-util-uri",
  "more-asserts",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -784,6 +784,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-mac"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
+dependencies = [
+ "generic-array",
+ "subtle",
+]
+
+[[package]]
 name = "csv"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2345,6 +2355,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "hmac"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
+dependencies = [
+ "crypto-mac 0.11.1",
+ "digest",
+]
+
+[[package]]
 name = "hmac-sha512"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2779,6 +2799,7 @@ dependencies = [
  "mc-util-serial",
  "prost",
  "rand_core 0.6.2",
+ "subtle",
  "zeroize",
 ]
 
@@ -3765,12 +3786,14 @@ dependencies = [
 name = "mc-transaction-core"
 version = "1.1.0"
 dependencies = [
+ "aes",
  "blake2",
  "bulletproofs",
  "curve25519-dalek",
  "displaydoc",
  "generic-array",
  "hex_fmt",
+ "hkdf",
  "lazy_static",
  "mc-account-keys",
  "mc-common",
@@ -3785,6 +3808,7 @@ dependencies = [
  "prost",
  "rand_core 0.6.2",
  "serde",
+ "sha2",
  "subtle",
  "zeroize",
 ]
@@ -3812,6 +3836,7 @@ dependencies = [
  "blake2",
  "curve25519-dalek",
  "displaydoc",
+ "hmac 0.11.0",
  "mc-account-keys",
  "mc-crypto-keys",
  "mc-fog-report-validation",
@@ -3821,6 +3846,8 @@ dependencies = [
  "prost",
  "rand 0.8.3",
  "rand_core 0.6.2",
+ "sha2",
+ "subtle",
  "zeroize",
 ]
 

--- a/android-bindings/src/bindings.rs
+++ b/android-bindings/src/bindings.rs
@@ -41,7 +41,7 @@ use mc_transaction_core::{
     tx::{Tx, TxOut, TxOutConfirmationNumber, TxOutMembershipProof},
     Amount, CompressedCommitment,
 };
-use mc_transaction_std::{InputCredentials, TransactionBuilder};
+use mc_transaction_std::{InputCredentials, RTHMemoBuilder, TransactionBuilder};
 use mc_util_from_random::FromRandom;
 use mc_util_uri::FogUri;
 use protobuf::Message;
@@ -1072,7 +1072,9 @@ pub unsafe extern "C" fn Java_com_mobilecoin_lib_TransactionBuilder_init_1jni(
     jni_ffi_call(&env, |env| {
         let fog_resolver: MutexGuard<FogResolver> =
             env.get_rust_field(fog_resolver, RUST_OBJ_FIELD)?;
-        let tx_builder = TransactionBuilder::new(fog_resolver.clone());
+        let memo_builder = RTHMemoBuilder::default();
+        // FIXME: Enable recoverable transaction history by configuring memo_builder
+        let tx_builder = TransactionBuilder::new(fog_resolver.clone(), memo_builder);
         Ok(env.set_rust_field(obj, RUST_OBJ_FIELD, tx_builder)?)
     })
 }
@@ -1211,7 +1213,7 @@ pub unsafe extern "C" fn Java_com_mobilecoin_lib_TransactionBuilder_set_1fee(
         let mut tx_builder: MutexGuard<TransactionBuilder<FogResolver>> =
             env.get_rust_field(obj, RUST_OBJ_FIELD)?;
 
-        tx_builder.set_fee(value as u64);
+        tx_builder.set_fee(value as u64)?;
 
         Ok(())
     })

--- a/android-bindings/src/bindings.rs
+++ b/android-bindings/src/bindings.rs
@@ -1187,6 +1187,10 @@ pub unsafe extern "C" fn Java_com_mobilecoin_lib_TransactionBuilder_add_1output(
     )
 }
 
+/// FIXME: The SDK should bind to "add_change_output" as well and use this
+/// when creating change outputs, otherwise recoverable transaction history
+/// won't work
+
 #[no_mangle]
 pub unsafe extern "C" fn Java_com_mobilecoin_lib_TransactionBuilder_set_1tombstone_1block(
     env: JNIEnv,

--- a/fog/api/proto/view.proto
+++ b/fog/api/proto/view.proto
@@ -262,4 +262,8 @@ message TxOutRecord {
     /// The client can recompute the tx_out_amount_commitment from the other data that we include.
     /// They can confirm correct recomputation by checking this crc value.
     fixed32 tx_out_amount_commitment_data_crc32 = 8;
+    /// The bytes of the encrypted memo.
+    /// This exactly 46 bytes when present.
+    /// This is omitted for TxOut's from before the upgrade that introduced memos.
+    bytes tx_out_e_memo_data = 9;
 }

--- a/fog/distribution/src/main.rs
+++ b/fog/distribution/src/main.rs
@@ -25,7 +25,7 @@ use mc_transaction_core::{
     tx::{Tx, TxOut, TxOutMembershipProof},
     validation::TransactionValidationError,
 };
-use mc_transaction_std::{InputCredentials, TransactionBuilder};
+use mc_transaction_std::{EmptyMemoBuilder, InputCredentials, TransactionBuilder};
 use mc_util_uri::FogUri;
 use rand::{seq::SliceRandom, thread_rng, Rng};
 use rayon::prelude::*;
@@ -475,9 +475,9 @@ fn build_tx(
     assert_eq!(utxos_with_proofs.len(), rings.len());
 
     // Create tx_builder.
-    let mut tx_builder = TransactionBuilder::new(fog_resolver);
+    let mut tx_builder = TransactionBuilder::new(fog_resolver, EmptyMemoBuilder::default());
 
-    tx_builder.set_fee(FEE.load(Ordering::SeqCst));
+    tx_builder.set_fee(FEE.load(Ordering::SeqCst)).unwrap();
 
     // Unzip each vec of tuples into a tuple of vecs.
     let mut rings_and_proofs: Vec<(Vec<TxOut>, Vec<TxOutMembershipProof>)> = rings

--- a/fog/fog_types/src/view.rs
+++ b/fog/fog_types/src/view.rs
@@ -309,7 +309,7 @@ impl core::convert::From<&TxOut> for FogTxOut {
             amount_commitment_data_crc32: crc32::checksum_ieee(
                 src.amount.commitment.point.as_bytes(),
             ),
-            e_memo: src.e_memo.clone(),
+            e_memo: src.e_memo,
         }
     }
 }
@@ -355,7 +355,7 @@ impl FogTxOut {
             target_key: self.target_key,
             public_key: self.public_key,
             e_fog_hint: EncryptedFogHint::from(&[0u8; ENCRYPTED_FOG_HINT_LEN]),
-            e_memo: self.e_memo.clone(),
+            e_memo: self.e_memo,
         })
     }
 }

--- a/fog/ingest/enclave/impl/tests/tx_processing.rs
+++ b/fog/ingest/enclave/impl/tests/tx_processing.rs
@@ -82,7 +82,7 @@ fn test_ingest_enclave(logger: Logger) {
         assert_eq!(tx_rows.len(), 10);
 
         // Check that the tx row ciphertexts have the right size
-        const EXPECTED_PAYLOAD_SIZE: usize = 159; // The observed tx_row.payload size
+        const EXPECTED_PAYLOAD_SIZE: usize = 207; // The observed tx_row.payload size
         for tx_row in tx_rows.iter() {
             assert_eq!(
                 tx_row.payload.len(), EXPECTED_PAYLOAD_SIZE,

--- a/fog/ingest/enclave/trusted/Cargo.lock
+++ b/fog/ingest/enclave/trusted/Cargo.lock
@@ -835,7 +835,7 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "blake2",
  "curve25519-dalek",
@@ -856,7 +856,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-ake"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "aead",
  "cargo-emit",
@@ -874,7 +874,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-core"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "binascii",
  "bitflags",
@@ -906,7 +906,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-enclave-api"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "displaydoc",
  "mc-attest-ake",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-trusted"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -929,7 +929,7 @@ dependencies = [
 
 [[package]]
 name = "mc-common"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "binascii",
  "cfg-if 0.1.10",
@@ -949,7 +949,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ake-enclave"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "aes-gcm",
  "digest",
@@ -968,7 +968,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-box"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "aead",
  "blake2",
@@ -982,7 +982,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "cfg-if 0.1.10",
  "curve25519-dalek",
@@ -995,7 +995,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-derive"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1004,7 +1004,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-signature"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "mc-crypto-digestible",
  "schnorrkel",
@@ -1013,7 +1013,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-hashes"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "blake2",
  "digest",
@@ -1022,7 +1022,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-keys"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "binascii",
  "curve25519-dalek",
@@ -1047,7 +1047,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-noise"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "aead",
  "aes-gcm",
@@ -1067,7 +1067,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-rand"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "cfg-if 0.1.10",
  "getrandom 0.1.13",
@@ -1078,7 +1078,7 @@ dependencies = [
 
 [[package]]
 name = "mc-enclave-boundary"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "mc-common",
  "mc-crypto-rand",
@@ -1089,7 +1089,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig-authority"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "mc-crypto-keys",
  "signature",
@@ -1149,11 +1149,11 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-alloc"
-version = "1.1.0"
+version = "1.1.1"
 
 [[package]]
 name = "mc-sgx-build"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "cc",
  "lazy_static",
@@ -1163,7 +1163,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-compat"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "cfg-if 0.1.10",
  "mc-sgx-alloc",
@@ -1176,7 +1176,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-css"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "displaydoc",
  "sha2",
@@ -1184,36 +1184,36 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-debug"
-version = "1.1.0"
+version = "1.1.1"
 
 [[package]]
 name = "mc-sgx-debug-edl"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-enclave-id"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "mc-sgx-types",
 ]
 
 [[package]]
 name = "mc-sgx-panic"
-version = "1.1.0"
+version = "1.1.1"
 
 [[package]]
 name = "mc-sgx-panic-edl"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-report-cache-api"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -1224,7 +1224,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-service"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "mc-sgx-build",
  "mc-sgx-types",
@@ -1232,7 +1232,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "cfg-if 0.1.10",
  "mc-common",
@@ -1242,14 +1242,14 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog-edl"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-sync"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "mc-sgx-panic",
  "mc-sgx-types",
@@ -1257,11 +1257,11 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-types"
-version = "1.1.0"
+version = "1.1.1"
 
 [[package]]
 name = "mc-transaction-core"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "aes",
  "blake2",
@@ -1292,7 +1292,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-script"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "cargo-emit",
  "displaydoc",
@@ -1303,7 +1303,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-sgx"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "cargo-emit",
  "cc",
@@ -1314,7 +1314,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-encodings"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "base64",
  "binascii",
@@ -1326,14 +1326,14 @@ dependencies = [
 
 [[package]]
 name = "mc-util-from-random"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "rand_core",
 ]
 
 [[package]]
 name = "mc-util-repr-bytes"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "generic-array",
  "prost",
@@ -1342,7 +1342,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-serial"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "prost",
  "serde",
@@ -1351,7 +1351,7 @@ dependencies = [
 
 [[package]]
 name = "mc-watcher-api"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "displaydoc",
  "serde",

--- a/fog/ingest/enclave/trusted/Cargo.lock
+++ b/fog/ingest/enclave/trusted/Cargo.lock
@@ -850,6 +850,7 @@ dependencies = [
  "mc-util-serial",
  "prost",
  "rand_core",
+ "subtle",
  "zeroize",
 ]
 
@@ -1262,12 +1263,14 @@ version = "1.1.0"
 name = "mc-transaction-core"
 version = "1.1.0"
 dependencies = [
+ "aes",
  "blake2",
  "bulletproofs",
  "curve25519-dalek",
  "displaydoc",
  "generic-array",
  "hex_fmt",
+ "hkdf",
  "lazy_static",
  "mc-account-keys",
  "mc-common",
@@ -1282,6 +1285,7 @@ dependencies = [
  "prost",
  "rand_core",
  "serde",
+ "sha2",
  "subtle",
  "zeroize",
 ]

--- a/fog/ingest/server/tests/three_node_cluster.rs
+++ b/fog/ingest/server/tests/three_node_cluster.rs
@@ -159,6 +159,7 @@ fn random_output<T: RngCore + CryptoRng>(rng: &mut T) -> Vec<TxOut> {
         target_key: RistrettoPublic::from_random(rng).into(),
         public_key: RistrettoPublic::from_random(rng).into(),
         e_fog_hint: EncryptedFogHint::default(),
+        e_memo: None,
     }]
 }
 

--- a/fog/ledger/enclave/trusted/Cargo.lock
+++ b/fog/ledger/enclave/trusted/Cargo.lock
@@ -835,7 +835,7 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "blake2",
  "curve25519-dalek",
@@ -856,7 +856,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-ake"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "aead",
  "cargo-emit",
@@ -874,7 +874,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-core"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "binascii",
  "bitflags",
@@ -906,7 +906,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-enclave-api"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "displaydoc",
  "mc-attest-ake",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-trusted"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -929,7 +929,7 @@ dependencies = [
 
 [[package]]
 name = "mc-common"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "binascii",
  "cfg-if 0.1.10",
@@ -949,7 +949,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ake-enclave"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "aes-gcm",
  "digest",
@@ -968,7 +968,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-box"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "aead",
  "blake2",
@@ -982,7 +982,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "cfg-if 0.1.10",
  "curve25519-dalek",
@@ -995,7 +995,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-derive"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1004,7 +1004,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-signature"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "mc-crypto-digestible",
  "schnorrkel",
@@ -1013,7 +1013,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-hashes"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "blake2",
  "digest",
@@ -1022,7 +1022,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-keys"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "binascii",
  "curve25519-dalek",
@@ -1047,7 +1047,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-noise"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "aead",
  "aes-gcm",
@@ -1067,7 +1067,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-rand"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "cfg-if 0.1.10",
  "getrandom 0.1.13",
@@ -1078,7 +1078,7 @@ dependencies = [
 
 [[package]]
 name = "mc-enclave-boundary"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "mc-common",
  "mc-crypto-rand",
@@ -1089,7 +1089,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig-authority"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "mc-crypto-keys",
  "signature",
@@ -1149,11 +1149,11 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-alloc"
-version = "1.1.0"
+version = "1.1.1"
 
 [[package]]
 name = "mc-sgx-build"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "cc",
  "lazy_static",
@@ -1163,7 +1163,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-compat"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "cfg-if 0.1.10",
  "mc-sgx-alloc",
@@ -1176,7 +1176,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-css"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "displaydoc",
  "sha2",
@@ -1184,36 +1184,36 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-debug"
-version = "1.1.0"
+version = "1.1.1"
 
 [[package]]
 name = "mc-sgx-debug-edl"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-enclave-id"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "mc-sgx-types",
 ]
 
 [[package]]
 name = "mc-sgx-panic"
-version = "1.1.0"
+version = "1.1.1"
 
 [[package]]
 name = "mc-sgx-panic-edl"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-report-cache-api"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -1224,7 +1224,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-service"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "mc-sgx-build",
  "mc-sgx-types",
@@ -1232,7 +1232,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "cfg-if 0.1.10",
  "mc-common",
@@ -1242,14 +1242,14 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog-edl"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-sync"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "mc-sgx-panic",
  "mc-sgx-types",
@@ -1257,11 +1257,11 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-types"
-version = "1.1.0"
+version = "1.1.1"
 
 [[package]]
 name = "mc-transaction-core"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "aes",
  "blake2",
@@ -1292,7 +1292,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-script"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "cargo-emit",
  "displaydoc",
@@ -1303,7 +1303,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-sgx"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "cargo-emit",
  "cc",
@@ -1314,7 +1314,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-encodings"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "base64",
  "binascii",
@@ -1326,14 +1326,14 @@ dependencies = [
 
 [[package]]
 name = "mc-util-from-random"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "rand_core",
 ]
 
 [[package]]
 name = "mc-util-repr-bytes"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "generic-array",
  "prost",
@@ -1342,7 +1342,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-serial"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "prost",
  "serde",
@@ -1351,7 +1351,7 @@ dependencies = [
 
 [[package]]
 name = "mc-watcher-api"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "displaydoc",
  "serde",

--- a/fog/ledger/enclave/trusted/Cargo.lock
+++ b/fog/ledger/enclave/trusted/Cargo.lock
@@ -850,6 +850,7 @@ dependencies = [
  "mc-util-serial",
  "prost",
  "rand_core",
+ "subtle",
  "zeroize",
 ]
 
@@ -1262,12 +1263,14 @@ version = "1.1.0"
 name = "mc-transaction-core"
 version = "1.1.0"
 dependencies = [
+ "aes",
  "blake2",
  "bulletproofs",
  "curve25519-dalek",
  "displaydoc",
  "generic-array",
  "hex_fmt",
+ "hkdf",
  "lazy_static",
  "mc-account-keys",
  "mc-common",
@@ -1282,6 +1285,7 @@ dependencies = [
  "prost",
  "rand_core",
  "serde",
+ "sha2",
  "subtle",
  "zeroize",
 ]

--- a/fog/ledger/server/src/merkle_proof_service.rs
+++ b/fog/ledger/server/src/merkle_proof_service.rs
@@ -250,6 +250,7 @@ mod test {
                 target_key: target_key.into(),
                 public_key: public_key.into(),
                 e_fog_hint: EncryptedFogHint::new(&[7u8; ENCRYPTED_FOG_HINT_LEN]),
+                e_memo: None,
             };
             tx_outs.push(tx_out);
         }

--- a/fog/sample-paykit/src/cached_tx_data/memo_handler.rs
+++ b/fog/sample-paykit/src/cached_tx_data/memo_handler.rs
@@ -1,0 +1,132 @@
+// Copyright (c) 2018-2021 The MobileCoin Foundation
+
+//! A memo handler object which processes memos, for use in integration tests
+
+use displaydoc::Display;
+use mc_account_keys::{AccountKey, AddressHash, PublicAddress, CHANGE_SUBADDRESS_INDEX};
+use mc_crypto_keys::{KeyError, RistrettoPublic};
+use mc_transaction_core::{get_tx_out_shared_secret, subaddress_matches_tx_out, tx::TxOut};
+use mc_transaction_std::{MemoDecodingError, MemoType};
+use std::{collections::HashMap, convert::TryFrom};
+
+/// A handler object that holds a contacts list and tries to recieve and
+/// authenticate memos. It provides the "get_last_memo" function which can be
+/// used to check what the last memo recieved was, and if there were validation
+/// errors.
+///
+/// This is useful for test code.
+#[derive(Debug, Clone)]
+pub struct MemoHandler {
+    contacts: HashMap<AddressHash, PublicAddress>,
+    last_memo: Result<Option<MemoType>, MemoHandlerError>,
+}
+
+impl MemoHandler {
+    /// Make a new memo handler with a given set of contacts
+    pub fn new(address_book: Vec<PublicAddress>) -> Self {
+        Self {
+            contacts: address_book
+                .into_iter()
+                .map(|addr| (AddressHash::from(&addr), addr))
+                .collect(),
+            last_memo: Ok(None),
+        }
+    }
+
+    /// Get the last memo, or memo handler error, that was processed, if any
+    pub fn get_last_memo(&self) -> &Result<Option<MemoType>, MemoHandlerError> {
+        &self.last_memo
+    }
+
+    /// Handle a memo
+    pub fn handle_memo(&mut self, tx_out: &TxOut, account_key: &AccountKey) {
+        self.last_memo = self.handle_memo_helper(tx_out, account_key);
+    }
+
+    // Helper for handle_memo function. The result of this gets assigned to
+    // self.last_memo, and so we can use rust ? syntax in this code.
+    fn handle_memo_helper(
+        &mut self,
+        tx_out: &TxOut,
+        account_key: &AccountKey,
+    ) -> Result<Option<MemoType>, MemoHandlerError> {
+        let decompressed_tx_pub = RistrettoPublic::try_from(&tx_out.public_key)?;
+        let shared_secret =
+            get_tx_out_shared_secret(account_key.view_private_key(), &decompressed_tx_pub);
+
+        let memo_payload = tx_out.decrypt_memo(&shared_secret);
+
+        let memo_type = MemoType::try_from(&memo_payload)?;
+        match memo_type.clone() {
+            MemoType::Unused(_) => Ok(None),
+            MemoType::AuthenticatedSender(memo) => {
+                if let Some(addr) = self.contacts.get(&memo.sender_address_hash()) {
+                    if bool::from(memo.validate(
+                        addr,
+                        account_key.view_private_key(),
+                        &tx_out.public_key,
+                    )) {
+                        Ok(Some(memo_type))
+                    } else {
+                        Err(MemoHandlerError::FailedHmacValidation)
+                    }
+                } else {
+                    Err(MemoHandlerError::UnknownSender)
+                }
+            }
+            MemoType::AuthenticatedSenderWithPaymentRequestId(memo) => {
+                if let Some(addr) = self.contacts.get(&memo.sender_address_hash()) {
+                    if bool::from(memo.validate(
+                        addr,
+                        account_key.view_private_key(),
+                        &tx_out.public_key,
+                    )) {
+                        Ok(Some(memo_type))
+                    } else {
+                        Err(MemoHandlerError::FailedHmacValidation)
+                    }
+                } else {
+                    Err(MemoHandlerError::UnknownSender)
+                }
+            }
+            MemoType::Destination(_) => {
+                if subaddress_matches_tx_out(account_key, CHANGE_SUBADDRESS_INDEX, tx_out)? {
+                    Ok(Some(memo_type))
+                } else {
+                    Err(MemoHandlerError::FailedSubaddressValidation)
+                }
+            }
+        }
+    }
+}
+
+/// An error that occurs when the memo handler can't process or validate a memo
+#[derive(Display, Debug, Clone)]
+pub enum MemoHandlerError {
+    /// Unknown Sender
+    UnknownSender,
+
+    /// Failed Hmac validation
+    FailedHmacValidation,
+
+    /// Failed subaddress validation
+    FailedSubaddressValidation,
+
+    /// Key: {0}
+    Key(KeyError),
+
+    /// Memo: {0}
+    Memo(MemoDecodingError),
+}
+
+impl From<KeyError> for MemoHandlerError {
+    fn from(src: KeyError) -> Self {
+        Self::Key(src)
+    }
+}
+
+impl From<MemoDecodingError> for MemoHandlerError {
+    fn from(src: MemoDecodingError) -> Self {
+        Self::Memo(src)
+    }
+}

--- a/fog/sample-paykit/src/cached_tx_data/memo_handler.rs
+++ b/fog/sample-paykit/src/cached_tx_data/memo_handler.rs
@@ -3,7 +3,7 @@
 //! A memo handler object which processes memos, for use in integration tests
 
 use displaydoc::Display;
-use mc_account_keys::{AccountKey, AddressHash, PublicAddress, CHANGE_SUBADDRESS_INDEX};
+use mc_account_keys::{AccountKey, PublicAddress, ShortAddressHash, CHANGE_SUBADDRESS_INDEX};
 use mc_common::logger::{log, Logger};
 use mc_crypto_keys::{KeyError, RistrettoPublic};
 use mc_transaction_core::{get_tx_out_shared_secret, subaddress_matches_tx_out, tx::TxOut};
@@ -18,7 +18,7 @@ use std::{collections::HashMap, convert::TryFrom};
 /// This is useful for test code.
 #[derive(Debug, Clone)]
 pub struct MemoHandler {
-    contacts: HashMap<AddressHash, PublicAddress>,
+    contacts: HashMap<ShortAddressHash, PublicAddress>,
     last_memo: Result<Option<MemoType>, MemoHandlerError>,
     logger: Logger,
 }
@@ -29,7 +29,7 @@ impl MemoHandler {
         Self {
             contacts: address_book
                 .into_iter()
-                .map(|addr| (AddressHash::from(&addr), addr))
+                .map(|addr| (ShortAddressHash::from(&addr), addr))
                 .collect(),
             last_memo: Ok(None),
             logger,

--- a/fog/sample-paykit/src/cached_tx_data/memo_handler.rs
+++ b/fog/sample-paykit/src/cached_tx_data/memo_handler.rs
@@ -119,8 +119,8 @@ pub enum MemoHandlerError {
     /// Key: {0}
     Key(KeyError),
 
-    /// Memo: {0}
-    Memo(MemoDecodingError),
+    /// Memo Decoding: {0}
+    MemoDecode(MemoDecodingError),
 }
 
 impl From<KeyError> for MemoHandlerError {
@@ -131,6 +131,6 @@ impl From<KeyError> for MemoHandlerError {
 
 impl From<MemoDecodingError> for MemoHandlerError {
     fn from(src: MemoDecodingError) -> Self {
-        Self::Memo(src)
+        Self::MemoDecode(src)
     }
 }

--- a/fog/sample-paykit/src/cached_tx_data/memo_handler.rs
+++ b/fog/sample-paykit/src/cached_tx_data/memo_handler.rs
@@ -67,7 +67,7 @@ impl MemoHandler {
                 if let Some(addr) = self.contacts.get(&memo.sender_address_hash()) {
                     if bool::from(memo.validate(
                         addr,
-                        account_key.default_subaddress_view_private(),
+                        &account_key.default_subaddress_view_private(),
                         &tx_out.public_key,
                     )) {
                         Ok(Some(memo_type))
@@ -82,7 +82,7 @@ impl MemoHandler {
                 if let Some(addr) = self.contacts.get(&memo.sender_address_hash()) {
                     if bool::from(memo.validate(
                         addr,
-                        account_key.default_subaddress_view_private(),
+                        &account_key.default_subaddress_view_private(),
                         &tx_out.public_key,
                     )) {
                         Ok(Some(memo_type))

--- a/fog/sample-paykit/src/cached_tx_data/memo_handler.rs
+++ b/fog/sample-paykit/src/cached_tx_data/memo_handler.rs
@@ -67,7 +67,7 @@ impl MemoHandler {
                 if let Some(addr) = self.contacts.get(&memo.sender_address_hash()) {
                     if bool::from(memo.validate(
                         addr,
-                        account_key.view_private_key(),
+                        account_key.default_subaddress_view_private(),
                         &tx_out.public_key,
                     )) {
                         Ok(Some(memo_type))
@@ -82,7 +82,7 @@ impl MemoHandler {
                 if let Some(addr) = self.contacts.get(&memo.sender_address_hash()) {
                     if bool::from(memo.validate(
                         addr,
-                        account_key.view_private_key(),
+                        account_key.default_subaddress_view_private(),
                         &tx_out.public_key,
                     )) {
                         Ok(Some(memo_type))

--- a/fog/sample-paykit/src/cached_tx_data/mod.rs
+++ b/fog/sample-paykit/src/cached_tx_data/mod.rs
@@ -86,7 +86,7 @@ impl CachedTxData {
             owned_tx_outs: Default::default(),
             key_image_data_completeness: BlockCount::MAX,
             latest_global_txo_count: 0,
-            memo_handler: MemoHandler::new(address_book),
+            memo_handler: MemoHandler::new(address_book, logger.clone()),
             logger,
         }
     }

--- a/fog/sample-paykit/src/client.rs
+++ b/fog/sample-paykit/src/client.rs
@@ -36,7 +36,8 @@ use mc_transaction_core::{
     BlockIndex,
 };
 use mc_transaction_std::{
-    InputCredentials, MemoType, RTHMemoBuilder, SenderMemoCredential, TransactionBuilder,
+    ChangeDestination, InputCredentials, MemoType, RTHMemoBuilder, SenderMemoCredential,
+    TransactionBuilder,
 };
 use mc_util_uri::{ConnectionUri, FogUri};
 use rand::Rng;
@@ -629,16 +630,14 @@ fn build_transaction_helper<T: RngCore + CryptoRng, FPR: FogPubkeyResolver>(
         .add_output(amount, target_address, rng)
         .map_err(Error::AddOutput)?;
 
-    if change > 0 {
-        let self_subaddress_for_change = source_account_key.default_subaddress();
+    let change_destination = ChangeDestination::from(source_account_key);
 
-        tx_builder
-            .add_output(change, &self_subaddress_for_change, rng)
-            .map_err(|err| {
-                log::error!(logger, "Could not add change due to {:?}", err);
-                Error::AddOutput(err)
-            })?;
-    }
+    tx_builder
+        .add_change_output(change, &change_destination, rng)
+        .map_err(|err| {
+            log::error!(logger, "Could not add change due to {:?}", err);
+            Error::AddOutput(err)
+        })?;
 
     tx_builder.set_tombstone_block(tombstone_block);
 

--- a/fog/sample-paykit/src/client_builder.rs
+++ b/fog/sample-paykit/src/client_builder.rs
@@ -9,7 +9,7 @@ use fog_ledger_connection::{
 use fog_uri::{FogLedgerUri, FogViewUri};
 use fog_view_connection::FogViewGrpcClient;
 use grpcio::EnvBuilder;
-use mc_account_keys::AccountKey;
+use mc_account_keys::{AccountKey, PublicAddress};
 use mc_attest_core::{Verifier, DEBUG_ENCLAVE};
 use mc_common::logger::{log, o, Logger};
 use mc_connection::{HardcodedCredentialsProvider, ThickClient};
@@ -35,6 +35,9 @@ pub struct ClientBuilder {
 
     // Ledger Server Details
     ledger_server_address: String,
+
+    // Address book
+    address_book: Vec<PublicAddress>,
 }
 
 // FIXME: ledger_server_address should be split into key_image_server and
@@ -55,6 +58,7 @@ impl ClientBuilder {
             ring_size: RING_SIZE,
             fog_view: fog_view_address,
             ledger_server_address,
+            address_book: Default::default(),
         }
     }
 
@@ -62,6 +66,13 @@ impl ClientBuilder {
     pub fn ring_size(self, ring_size: usize) -> Self {
         let mut retval = self;
         retval.ring_size = ring_size;
+        retval
+    }
+
+    /// Sets the address book for the client, used with memos
+    pub fn address_book(self, address_book: Vec<PublicAddress>) -> Self {
+        let mut retval = self;
+        retval.address_book = address_book;
         retval
     }
 
@@ -132,6 +143,7 @@ impl ClientBuilder {
             fog_untrusted,
             self.ring_size,
             self.key.clone(),
+            self.address_book.clone(),
             self.logger.clone(),
         )
     }

--- a/fog/sample-paykit/src/lib.rs
+++ b/fog/sample-paykit/src/lib.rs
@@ -28,6 +28,7 @@ pub use crate::{
     client_builder::ClientBuilder,
     error::{Error, Result, TxOutMatchingError},
 };
+pub use cached_tx_data::MemoHandlerError;
 pub use mc_account_keys::{AccountKey, PublicAddress};
 pub use mc_crypto_keys::{RistrettoPrivate, RistrettoPublic};
 pub use mc_transaction_core::{

--- a/fog/test-client/Cargo.toml
+++ b/fog/test-client/Cargo.toml
@@ -11,9 +11,11 @@ name = "test_client"
 path = "src/bin/main.rs"
 
 [dependencies]
+mc-account-keys = { path = "../../mobilecoin/account-keys" }
 mc-common = { path = "../../mobilecoin/common", features = ["log"] }
 mc-crypto-rand = { path = "../../mobilecoin/crypto/rand" }
 mc-transaction-core = { path = "../../mobilecoin/transaction/core" }
+mc-transaction-std = { path = "../../mobilecoin/transaction/std" }
 mc-util-keyfile = { path = "../../mobilecoin/util/keyfile" }
 mc-util-uri = { path = "../../mobilecoin/util/uri" }
 

--- a/fog/test-client/src/test_client.rs
+++ b/fog/test-client/src/test_client.rs
@@ -366,10 +366,10 @@ impl TestClient {
                     }
                 },
                 Ok(None) => {
-                    panic!("source client didn't find destination memo");
+                    panic!("target client didn't find sender memo");
                 }
                 Err(err) => {
-                    panic!("source client memo error: {}", err);
+                    panic!("target client memo error: {}", err);
                 }
             }
 

--- a/fog/test-client/src/test_client.rs
+++ b/fog/test-client/src/test_client.rs
@@ -327,7 +327,7 @@ impl TestClient {
             match source_client.get_last_memo() {
                 Ok(Some(memo)) => match memo {
                     MemoType::Destination(memo) => {
-                        assert_eq!(memo.get_total_outlay(), self.transfer_amount);
+                        assert_eq!(memo.get_total_outlay(), self.transfer_amount + fee);
                         assert_eq!(memo.get_fee(), fee);
                         assert_eq!(memo.get_num_recipients(), 1);
                         assert_eq!(

--- a/fog/test-client/src/test_client.rs
+++ b/fog/test-client/src/test_client.rs
@@ -5,12 +5,14 @@
 use crate::error::TestClientError;
 
 use fog_sample_paykit::{AccountKey, Client, ClientBuilder, TransactionStatus, Tx};
+use mc_account_keys::AddressHash;
 use mc_common::logger::{log, Logger};
 use mc_crypto_rand::McRng;
 use mc_transaction_core::{
     constants::{MINIMUM_FEE, RING_SIZE},
     BlockIndex,
 };
+use mc_transaction_std::MemoType;
 use mc_util_uri::ConsensusClientUri;
 use more_asserts::assert_gt;
 use std::{
@@ -78,6 +80,13 @@ impl TestClient {
         // Need at least 2 clients to send transactions to each other.
         assert_gt!(client_count, 1);
 
+        // Build an address book for each client
+        let address_book: Vec<_> = self
+            .account_keys
+            .iter()
+            .map(|x| x.default_subaddress())
+            .collect();
+
         for (i, account_key) in self.account_keys.iter().enumerate() {
             log::debug!(
                 self.logger,
@@ -94,6 +103,7 @@ impl TestClient {
                 self.logger.clone(),
             )
             .ring_size(RING_SIZE)
+            .address_book(address_book.clone())
             .build();
             clients.push(client);
         }
@@ -311,6 +321,57 @@ impl TestClient {
                 transaction_appeared,
                 tgt_balance + self.transfer_amount,
             )?;
+
+            // Ensure source client got a destination memo, as expected for recoverable
+            // transcation history
+            match source_client.get_last_memo() {
+                Ok(Some(memo)) => match memo {
+                    MemoType::Destination(memo) => {
+                        assert_eq!(memo.get_total_outlay(), self.transfer_amount);
+                        assert_eq!(memo.get_fee(), fee);
+                        assert_eq!(memo.get_num_recipients(), 1);
+                        assert_eq!(
+                            *memo.get_address_hash(),
+                            AddressHash::from(
+                                &target_client.get_account_key().default_subaddress()
+                            )
+                        );
+                    }
+                    _ => {
+                        panic!("unexpected memo type")
+                    }
+                },
+                Ok(None) => {
+                    panic!("source client didn't find destination memo");
+                }
+                Err(err) => {
+                    panic!("source client memo error: {}", err);
+                }
+            }
+
+            // Ensure target client got a sender memo, as expected for recoverable
+            // transcation history
+            match target_client.get_last_memo() {
+                Ok(Some(memo)) => match memo {
+                    MemoType::AuthenticatedSender(memo) => {
+                        assert_eq!(
+                            memo.sender_address_hash(),
+                            AddressHash::from(
+                                &source_client.get_account_key().default_subaddress()
+                            )
+                        );
+                    }
+                    _ => {
+                        panic!("unexpected memo type")
+                    }
+                },
+                Ok(None) => {
+                    panic!("source client didn't find destination memo");
+                }
+                Err(err) => {
+                    panic!("source client memo error: {}", err);
+                }
+            }
 
             // Attempt double spend on the last transaction. This is an expensive test.
             if ti == self.transactions - 1 {

--- a/fog/test-client/src/test_client.rs
+++ b/fog/test-client/src/test_client.rs
@@ -5,7 +5,7 @@
 use crate::error::TestClientError;
 
 use fog_sample_paykit::{AccountKey, Client, ClientBuilder, TransactionStatus, Tx};
-use mc_account_keys::AddressHash;
+use mc_account_keys::ShortAddressHash;
 use mc_common::logger::{log, Logger};
 use mc_crypto_rand::McRng;
 use mc_transaction_core::{
@@ -332,7 +332,7 @@ impl TestClient {
                         assert_eq!(memo.get_num_recipients(), 1);
                         assert_eq!(
                             *memo.get_address_hash(),
-                            AddressHash::from(
+                            ShortAddressHash::from(
                                 &target_client.get_account_key().default_subaddress()
                             )
                         );
@@ -356,7 +356,7 @@ impl TestClient {
                     MemoType::AuthenticatedSender(memo) => {
                         assert_eq!(
                             memo.sender_address_hash(),
-                            AddressHash::from(
+                            ShortAddressHash::from(
                                 &source_client.get_account_key().default_subaddress()
                             )
                         );

--- a/fog/test_infra/src/mock_users.rs
+++ b/fog/test_infra/src/mock_users.rs
@@ -102,7 +102,7 @@ pub fn test_block_to_pairs(test_block: &TestBlock) -> Vec<(UserPrivate, TxOut)> 
     result
 }
 
-/// Make a random transaction targeted at a specific user.
+/// Make a random transaction targeted at a specific user via fog
 pub fn make_random_tx<T: RngCore + CryptoRng>(
     rng: &mut T,
     acct_server_pubkey: &RistrettoPublic,
@@ -115,6 +115,7 @@ pub fn make_random_tx<T: RngCore + CryptoRng>(
         target_key: target_key.into(),
         public_key: public_key.into(),
         e_fog_hint: recipient.encrypt(acct_server_pubkey, rng),
+        e_memo: None,
     }
 }
 

--- a/fog/view/enclave/trusted/Cargo.lock
+++ b/fog/view/enclave/trusted/Cargo.lock
@@ -824,6 +824,7 @@ dependencies = [
  "mc-util-serial",
  "prost",
  "rand_core",
+ "subtle",
  "zeroize",
 ]
 
@@ -1245,12 +1246,14 @@ version = "1.1.0"
 name = "mc-transaction-core"
 version = "1.1.0"
 dependencies = [
+ "aes",
  "blake2",
  "bulletproofs",
  "curve25519-dalek",
  "displaydoc",
  "generic-array",
  "hex_fmt",
+ "hkdf",
  "lazy_static",
  "mc-account-keys",
  "mc-common",
@@ -1265,6 +1268,7 @@ dependencies = [
  "prost",
  "rand_core",
  "serde",
+ "sha2",
  "subtle",
  "zeroize",
 ]

--- a/fog/view/enclave/trusted/Cargo.lock
+++ b/fog/view/enclave/trusted/Cargo.lock
@@ -809,7 +809,7 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "blake2",
  "curve25519-dalek",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-ake"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "aead",
  "cargo-emit",
@@ -848,7 +848,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-core"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "binascii",
  "bitflags",
@@ -880,7 +880,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-enclave-api"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "displaydoc",
  "mc-attest-ake",
@@ -892,7 +892,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-trusted"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -903,7 +903,7 @@ dependencies = [
 
 [[package]]
 name = "mc-common"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "binascii",
  "cfg-if 0.1.10",
@@ -923,7 +923,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ake-enclave"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "aes-gcm",
  "digest",
@@ -942,7 +942,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-box"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "aead",
  "blake2",
@@ -956,7 +956,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "cfg-if 0.1.10",
  "curve25519-dalek",
@@ -969,7 +969,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-derive"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -978,7 +978,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-signature"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "mc-crypto-digestible",
  "schnorrkel",
@@ -987,7 +987,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-hashes"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "blake2",
  "digest",
@@ -996,7 +996,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-keys"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "binascii",
  "curve25519-dalek",
@@ -1021,7 +1021,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-noise"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "aead",
  "aes-gcm",
@@ -1041,7 +1041,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-rand"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "cfg-if 0.1.10",
  "getrandom 0.1.13",
@@ -1052,7 +1052,7 @@ dependencies = [
 
 [[package]]
 name = "mc-enclave-boundary"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "mc-common",
  "mc-crypto-rand",
@@ -1063,7 +1063,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig-authority"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "mc-crypto-keys",
  "signature",
@@ -1123,11 +1123,11 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-alloc"
-version = "1.1.0"
+version = "1.1.1"
 
 [[package]]
 name = "mc-sgx-build"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "cc",
  "lazy_static",
@@ -1137,7 +1137,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-compat"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "cfg-if 0.1.10",
  "mc-sgx-alloc",
@@ -1150,7 +1150,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-compat-edl"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "cargo-emit",
  "mc-sgx-debug-edl",
@@ -1159,7 +1159,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-css"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "displaydoc",
  "sha2",
@@ -1167,36 +1167,36 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-debug"
-version = "1.1.0"
+version = "1.1.1"
 
 [[package]]
 name = "mc-sgx-debug-edl"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-enclave-id"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "mc-sgx-types",
 ]
 
 [[package]]
 name = "mc-sgx-panic"
-version = "1.1.0"
+version = "1.1.1"
 
 [[package]]
 name = "mc-sgx-panic-edl"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-report-cache-api"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -1207,7 +1207,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-service"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "mc-sgx-build",
  "mc-sgx-types",
@@ -1215,7 +1215,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "cfg-if 0.1.10",
  "mc-common",
@@ -1225,14 +1225,14 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog-edl"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-sync"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "mc-sgx-panic",
  "mc-sgx-types",
@@ -1240,11 +1240,11 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-types"
-version = "1.1.0"
+version = "1.1.1"
 
 [[package]]
 name = "mc-transaction-core"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "aes",
  "blake2",
@@ -1275,7 +1275,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-script"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "cargo-emit",
  "displaydoc",
@@ -1286,7 +1286,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-sgx"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "cargo-emit",
  "cc",
@@ -1297,7 +1297,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-encodings"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "base64",
  "binascii",
@@ -1309,14 +1309,14 @@ dependencies = [
 
 [[package]]
 name = "mc-util-from-random"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "rand_core",
 ]
 
 [[package]]
 name = "mc-util-repr-bytes"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "generic-array",
  "prost",
@@ -1325,7 +1325,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-serial"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "prost",
  "serde",
@@ -1334,7 +1334,7 @@ dependencies = [
 
 [[package]]
 name = "mc-watcher-api"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "displaydoc",
  "serde",

--- a/libmobilecoin/src/transaction.rs
+++ b/libmobilecoin/src/transaction.rs
@@ -449,10 +449,10 @@ pub extern "C" fn mc_transaction_builder_add_output_with_fog_hint_address(
     out_tx_out_confirmation_number: FfiMutPtr<McMutableBuffer>,
     out_error: FfiOptMutPtr<FfiOptOwnedPtr<McError>>,
 ) -> FfiOptOwnedPtr<McData> {
-    /// FIXME: The SDK should probably stop binding to this function, I don't
-    /// believe there is legitimate use for this.
-    /// It should bind "add_change_output" instead.
-    /// Please speak to me if you disagree.
+    // FIXME(chris): The SDK should probably stop binding to this function, I don't
+    // believe that there is legitimate use for this.
+    // It should bind "add_change_output" instead.
+    // Please speak to me if you disagree.
     ffi_boundary_with_error(out_error, || {
         let transaction_builder = transaction_builder
             .into_mut()

--- a/libmobilecoin/src/transaction.rs
+++ b/libmobilecoin/src/transaction.rs
@@ -449,6 +449,10 @@ pub extern "C" fn mc_transaction_builder_add_output_with_fog_hint_address(
     out_tx_out_confirmation_number: FfiMutPtr<McMutableBuffer>,
     out_error: FfiOptMutPtr<FfiOptOwnedPtr<McError>>,
 ) -> FfiOptOwnedPtr<McData> {
+    /// FIXME: The SDK should probably stop binding to this function, I don't
+    /// believe there is legitimate use for this.
+    /// It should bind "add_change_output" instead.
+    /// Please speak to me if you disagree.
     ffi_boundary_with_error(out_error, || {
         let transaction_builder = transaction_builder
             .into_mut()

--- a/libmobilecoin/src/transaction.rs
+++ b/libmobilecoin/src/transaction.rs
@@ -10,9 +10,9 @@ use mc_transaction_core::{
     onetime_keys::{recover_onetime_private_key, recover_public_subaddress_spend_key},
     ring_signature::KeyImage,
     tx::{TxOut, TxOutConfirmationNumber, TxOutMembershipProof},
-    Amount, CompressedCommitment,
+    Amount, CompressedCommitment, MemoPayload,
 };
-use mc_transaction_std::{InputCredentials, TransactionBuilder};
+use mc_transaction_std::{InputCredentials, RTHMemoBuilder, TransactionBuilder};
 use mc_util_ffi::*;
 
 /* ==== TxOut ==== */
@@ -301,8 +301,12 @@ pub extern "C" fn mc_transaction_builder_create(
                     FogResolver::new(fog_resolver.0.clone(), &fog_resolver.1)
                         .expect("FogResolver could not be constructed from the provided materials")
                 });
-        let mut transaction_builder = TransactionBuilder::new(fog_resolver);
-        transaction_builder.set_fee(fee);
+        let memo_builder = RTHMemoBuilder::default();
+        // FIXME: Enable recoverable transaction history by configuring memo_builder
+        let mut transaction_builder = TransactionBuilder::new(fog_resolver, memo_builder);
+        transaction_builder
+            .set_fee(fee)
+            .expect("failure not expected");
         transaction_builder.set_tombstone_block(tombstone_block);
         Some(transaction_builder)
     })
@@ -464,6 +468,7 @@ pub extern "C" fn mc_transaction_builder_add_output_with_fog_hint_address(
             amount,
             &recipient_address,
             &fog_hint_address,
+            |_| Ok(MemoPayload::default()),
             &mut rng,
         )?;
 


### PR DESCRIPTION
This makes fog ingest include the encrypted memo in the TxOutRecord
object. It then passes through fog view as usual. We also update
the FogTxOut object to parse the memo out of the view response.

fog sample paykit is updated to both produce memos on new transactions,
and parse memos from incoming transactions, and remember the last one or an error.

This uprevs mobilecoin submodule, and makes the android bindings
and libmobilecoin able to build.

It installs a RTHMemoBuilder when those bindings create transaction
builder, but it does not configure the RTHMemoBuilder, because
we probably need to extend the bindings to do that properly.

It also gets all the tests passing

Still TODO:
- [x] Make sample paykit actually read the memos and expose this info in some basic way
- [x] Make fog test client confirm that the memos are working (if A sends to B then B got the right memo and so did A)