### PR TITLE
initial change to consolidate get watcher timestamp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1346,6 +1346,7 @@ dependencies = [
  "fog-recovery-db-iface",
  "fog-sql-recovery-db",
  "fog-test-infra",
+ "fog-timestamps",
  "fog-types",
  "fog-uri",
  "futures",
@@ -1523,6 +1524,7 @@ dependencies = [
  "fog-ledger-enclave-measurement",
  "fog-ledger-test-infra",
  "fog-test-infra",
+ "fog-timestamps",
  "fog-types",
  "fog-uri",
  "futures",
@@ -1834,6 +1836,16 @@ dependencies = [
  "serde_json",
  "structopt",
  "url",
+]
+
+[[package]]
+name = "fog-timestamps"
+version = "0.1.0"
+dependencies = [
+ "mc-common",
+ "mc-transaction-core",
+ "mc-watcher",
+ "mc-watcher-api",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "benchmarks",
     "fog/api",
     "fog/distribution",
+    "fog/fog_timestamps",
     "fog/fog_types",
     "fog/ingest/client",
     "fog/ingest/enclave",

--- a/fog/fog_timestamps/Cargo.toml
+++ b/fog/fog_timestamps/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "fog-timestamps"
+version = "0.1.0"
+authors = ["MobileCoin"]
+edition = "2018"
+license = "GPL-3.0"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+# root
+mc-common = { path = "../../mobilecoin/common", features = ["loggers"] }
+mc-transaction-core = { path = "../../mobilecoin/transaction/core" }
+mc-watcher = { path = "../../mobilecoin/watcher" }
+mc-watcher-api = { path = "../../mobilecoin/watcher/api" }

--- a/fog/fog_timestamps/src/lib.rs
+++ b/fog/fog_timestamps/src/lib.rs
@@ -1,0 +1,3 @@
+// Copyright (c) 2018-2021 The MobileCoin Foundation
+
+pub mod watcher;

--- a/fog/fog_timestamps/src/watcher.rs
+++ b/fog/fog_timestamps/src/watcher.rs
@@ -1,0 +1,71 @@
+// Copyright (c) 2018-2021 The MobileCoin Foundation
+
+use mc_common::logger::{log, Logger};
+use mc_transaction_core::BlockIndex;
+use mc_watcher::watcher_db::WatcherDB;
+use mc_watcher_api::TimestampResultCode;
+use std::time::{Duration, Instant};
+
+/// Poll for new data every 10 ms
+const POLLING_FREQUENCY: Duration = Duration::from_millis(10);
+/// If a database invariant is violated, e.g. we get block but not block
+/// contents, it typically will not be fixed and so we won't be able to
+/// proceed. But bringing the server down is costly from ops POV because
+/// we will lose all the user rng's.
+///
+/// So instead, if this happens, we log an error, and retry in 1s.
+/// This avoids logging at > 1hz when there is this error, which would be
+/// very spammy. But the retries are unlikely to eventually lead to
+/// progress. Another strategy might be for the server to enter a
+/// "paused" state and signal for intervention.
+const ERROR_RETRY_FREQUENCY: Duration = Duration::from_millis(1000);
+
+// Get the timestamp from the watcher, or an error code,
+// using retries if the watcher fell behind
+pub fn get_watcher_timestamp(
+    block_index: BlockIndex,
+    watcher: &WatcherDB,
+    watcher_timeout: Duration,
+    logger: &Logger,
+) -> u64 {
+    // Timer that tracks how long we have had WatcherBehind error for,
+    // if this exceeds watcher_timeout, we log a warning.
+    let mut watcher_behind_timer = Instant::now();
+    loop {
+        match watcher.get_block_timestamp(block_index) {
+            Ok((ts, res)) => match res {
+                TimestampResultCode::WatcherBehind => {
+                    if watcher_behind_timer.elapsed() > watcher_timeout {
+                        log::warn!(logger, "watcher is still behind on block index = {} after waiting {} seconds, ingest will be blocked", block_index, watcher_timeout.as_secs());
+                        watcher_behind_timer = Instant::now();
+                    }
+                    std::thread::sleep(POLLING_FREQUENCY);
+                }
+                TimestampResultCode::BlockIndexOutOfBounds => {
+                    log::warn!(logger, "block index {} was out of bounds, we should not be scanning it, we will have junk timestamps for it", block_index);
+                    return u64::MAX;
+                }
+                TimestampResultCode::Unavailable => {
+                    log::crit!(logger, "watcher configuration is wrong and timestamps will not be available with this configuration. Ingest is blocked at block index {}", block_index);
+                    std::thread::sleep(ERROR_RETRY_FREQUENCY);
+                }
+                TimestampResultCode::WatcherDatabaseError => {
+                    log::crit!(logger, "The watcher database has an error which prevents us from getting timestamps. Ingest is blocked at block index {}", block_index);
+                    std::thread::sleep(ERROR_RETRY_FREQUENCY);
+                }
+                TimestampResultCode::TimestampFound => {
+                    return ts;
+                }
+            },
+            Err(err) => {
+                log::error!(
+                        logger,
+                        "Could not obtain timestamp for block {} due to error {}, this may mean the watcher is not correctly configured. will retry",
+                        block_index,
+                        err
+                    );
+                std::thread::sleep(ERROR_RETRY_FREQUENCY);
+            }
+        };
+    }
+}

--- a/fog/ingest/server/Cargo.toml
+++ b/fog/ingest/server/Cargo.toml
@@ -56,6 +56,7 @@ fog-ingest-enclave-api = { path = "../enclave/api" }
 fog-ingest-enclave-measurement = { path = "../enclave/measurement" }
 fog-recovery-db-iface = { path = "../../recovery_db_iface" }
 fog-sql-recovery-db = { path = "../../sql_recovery_db" }
+fog-timestamps = { path = "../../fog_timestamps" }
 fog-types = { path = "../../fog_types" }
 fog-uri = { path = "../../uri" }
 

--- a/fog/ledger/server/Cargo.toml
+++ b/fog/ledger/server/Cargo.toml
@@ -37,6 +37,7 @@ fog-api = { path = "../../api" }
 fog-uri = { path = "../../uri" }
 fog-ledger-enclave = { path = "../enclave" }
 fog-ledger-enclave-api = { path = "../enclave/api" }
+fog-timestamps = { path = "../../fog_timestamps" }
 fog-types = { path = "../../fog_types" }
 
 displaydoc = { version = "0.2", default-features = false }

--- a/fog/ledger/server/src/db_fetcher.rs
+++ b/fog/ledger/server/src/db_fetcher.rs
@@ -11,9 +11,7 @@ use mc_common::{
     trace_time,
 };
 use mc_ledger_db::{self, Error as LedgerError, Ledger};
-use mc_transaction_core::BlockIndex;
 use mc_watcher::watcher_db::WatcherDB;
-use mc_watcher_api::TimestampResultCode;
 use retry::{delay, retry, OperationResult};
 use std::{
     sync::{
@@ -21,7 +19,7 @@ use std::{
         Arc, Mutex,
     },
     thread::{Builder as ThreadBuilder, JoinHandle},
-    time::{Duration, Instant},
+    time::Duration,
 };
 
 /// An object for managing background data fetches from the ledger database.
@@ -157,7 +155,7 @@ impl<DB: Ledger, E: LedgerEnclaveProxy + Clone + Send + Sync + 'static> DbFetche
             }
             Ok(block_contents) => {
                 // Get the timestamp for the block.
-                let timestamp = Self::get_watcher_timestamp(
+                let timestamp = fog_timestamps::watcher::get_watcher_timestamp(
                     self.next_block_index,
                     &self.watcher,
                     watcher_timeout,
@@ -198,61 +196,6 @@ impl<DB: Ledger, E: LedgerEnclaveProxy + Clone + Send + Sync + 'static> DbFetche
             }
         }
         has_more_work
-    }
-
-    // Get the timestamp from the watcher, or an error code,
-    // using retries if the watcher fell behind
-    fn get_watcher_timestamp(
-        block_index: BlockIndex,
-        watcher: &WatcherDB,
-        watcher_timeout: Duration,
-        logger: &Logger,
-    ) -> u64 {
-        // special case the origin block has a timestamp of u64::MAX
-        if block_index == 0 {
-            return u64::MAX;
-        }
-
-        // Timer that tracks how long we have had WatcherBehind error for,
-        // if this exceeds watcher_timeout, we log a warning.
-        let mut watcher_behind_timer = Instant::now();
-        loop {
-            match watcher.get_block_timestamp(block_index) {
-                Ok((ts, res)) => match res {
-                    TimestampResultCode::WatcherBehind => {
-                        if watcher_behind_timer.elapsed() > watcher_timeout {
-                            log::warn!(logger, "watcher is still behind on block index = {} after waiting {} seconds, ledger service will be blocked", block_index, watcher_timeout.as_secs());
-                            watcher_behind_timer = Instant::now();
-                        }
-                        std::thread::sleep(Self::POLLING_FREQUENCY);
-                    }
-                    TimestampResultCode::BlockIndexOutOfBounds => {
-                        log::warn!(logger, "block index {} was out of bounds, we should not be scanning it, we will have junk timestamps for it", block_index);
-                        return u64::MAX;
-                    }
-                    TimestampResultCode::Unavailable => {
-                        log::crit!(logger, "watcher configuration is wrong and timestamps will not be available with this configuration. Ledger service is blocked at block index {}", block_index);
-                        std::thread::sleep(Self::ERROR_RETRY_FREQUENCY);
-                    }
-                    TimestampResultCode::WatcherDatabaseError => {
-                        log::crit!(logger, "The watcher database has an error which prevents us from getting timestamps. Ledger service is blocked at block index {}", block_index);
-                        std::thread::sleep(Self::ERROR_RETRY_FREQUENCY);
-                    }
-                    TimestampResultCode::TimestampFound => {
-                        return ts;
-                    }
-                },
-                Err(err) => {
-                    log::error!(
-                        logger,
-                        "Could not obtain timestamp for block {} due to error {}, this may mean the watcher is not correctly configured. will retry",
-                        block_index,
-                        err
-                    );
-                    std::thread::sleep(Self::ERROR_RETRY_FREQUENCY);
-                }
-            };
-        }
     }
 
     fn add_records_to_enclave(&mut self, block_index: u64, records: Vec<KeyImageData>) {


### PR DESCRIPTION
Soundtrack of this PR: [link to song that really fits the mood of this PR]()

### Motivation

Currently the watcher database provides an API for getting block signatures and from there we can get timestamps for a block. However, sometimes the watcher fails or gets stuck. Both fog ingest and fog ledger have code for handling these errors and retries. Because the clients need a timestamp on every piece of data in order to function, failing to get a timestamp blocks the service, and immediately escalates to a P0 issue. We now have the code for getting the timestamps from the watcher in two places — in the fog-ingest worker thread and in the fog ledger worker thread, and specifically a function "get_watcher_timestamp" .https://github.com/mobilecoinfoundation/fog/blob/5a776bd027e1e2cc5f4717f4d4f8f56f30ae0585/fog/ingest/server/src/worker.rs#L151
that is duplicated in both places.

### In this PR
It would be better to have a crate like "fog-timestamps" to provides this function, and reconcile any differences between the two versions, and test this. So that we know it works the same way everywhere, and this will make it easier to debug if fog gets blocked on this in production (which has happened before, and will happen again).

< Ticket status, e.g. "fixes #issue number" > 
https://app.asana.com/0/1200353042931237/1200688378834228/f

### Future Work
* < Out of scope non-goals for this PR >
* < These should be links to tickets. If the tickets do not exist, make them. >

