### PR TITLE
Fogdistrotransactionchanges

### DIFF
--- a/fog/distribution/src/main.rs
+++ b/fog/distribution/src/main.rs
@@ -320,10 +320,7 @@ fn build_fog_resolver(
         verifier
     };
 
-    let fog_resolver =
-        FogResolver::new(responses, &report_verifier).expect("Could not get FogResolver");
-
-    fog_resolver
+    FogResolver::new(responses, &report_verifier).expect("Could not get FogResolver")
 }
 
 fn worker_thread_entry(


### PR DESCRIPTION
Soundtrack of this PR: [link to song that really fits the mood of this PR]()

### Motivation

Currently Fog distro is a modified version of slam that sends fog transactions. What causes it to give up is, it builds a bunch of transactions in one thread, Then a sender thread just hits consensus and tries to submit. And if there is an error it retries. However, sometimes the transaction will never succeed, if it was built a while ago with old tombstone block / older fog report. So that would cause distro to fail entirely. So we made distro stop retrying in those cases. But what it should actually do is rebuild the transaction

### In this PR
Add transaction to a queue of transactions to rebuild when distro fails due to old tombstone block

< Ticket status, e.g. "fixes #issue number" > 

### Future Work
* < Out of scope non-goals for this PR >
* < These should be links to tickets. If the tickets do not exist, make them. >

