### PR TITLE
Reduce an error level (1.1.2 branch)

### DIFF
--- a/fog/ingest/server/src/controller.rs
+++ b/fog/ingest/server/src/controller.rs
@@ -411,11 +411,19 @@ where
                             return;
                         }
                     }
-                    Err(err) => {
-                        // Failing to publish a report is not fatal, because we attempt to publish
+                    Err(Error::PublishReport) => {
+                        // This is already logged adequately within
+                        // self.publish_report
+                        //
+                        // Failing to publish a report is not fatal, because we
+                        // attempt to publish
                         // on every block, and even if it only succeeds half
                         // the time, it wont make much difference in the pubkey
                         // expiry window.
+                    }
+                    Err(err) => {
+                        // If the error is something other than PublishReport then we should log it
+                        // at a high severity level
                         log::error!(
                             self.logger,
                             "Could not publish ingest report at block index {}: {}",
@@ -1148,7 +1156,7 @@ where
         };
         let report_id = self.config.fog_report_id.as_ref();
 
-        log::info!(self.logger, "publishing report to sql");
+        log::info!(self.logger, "publishing report to DB");
         self.recovery_db
             .set_report(ingress_public_key, report_id, &report_data)
             .map(|x| {
@@ -1156,9 +1164,12 @@ where
                 x
             })
             .map_err(|err| {
-                log::error!(
+                // This is a warning because transient report DB write errors are not a cause
+                // for action, as long as this write succeeds eventually it's
+                // fine.
+                log::warn!(
                     self.logger,
-                    "Could not publish report and check on ingress key status: {}",
+                    "Could not publish report to DB and check on ingress key status: {}",
                     err
                 );
                 // Note: At this revision, we don't have generic constraints for converting


### PR DESCRIPTION
Sometimes, we lose connection to the sql DB, and the report server write operation fails.

This should not be logged as an error because it's not actionable and errors get converted to sentry alerts.