### PR TITLE
This backports a config parameter that is already in master

### DIFF
--- a/fog/view/server/src/bin/main.rs
+++ b/fog/view/server/src/bin/main.rs
@@ -11,9 +11,6 @@ use mc_util_grpc::AdminServer;
 use std::{env, sync::Arc};
 use structopt::StructOpt;
 
-// FIXME: This should be a config parameter
-const VIEW_OMAP_CAPACITY: u64 = 1024 * 1024;
-
 fn main() {
     mc_common::setup_panic_handler();
     let _sentry_guard = mc_common::sentry::init();
@@ -40,7 +37,7 @@ fn main() {
     let sgx_enclave = SgxViewEnclave::new(
         enclave_path,
         config.client_responder_id.clone(),
-        VIEW_OMAP_CAPACITY,
+        config.omap_capacity,
         logger.clone(),
     );
 

--- a/fog/view/server/src/config.rs
+++ b/fog/view/server/src/config.rs
@@ -50,6 +50,15 @@ pub struct MobileAcctViewConfig {
     /// Postgres config
     #[structopt(flatten)]
     pub postgres_config: SqlRecoveryDbConnectionConfig,
+
+    /// OMAP capacity. Must be a power of two.
+    /// The capacity (of ETxOutRecords) of the Oblivious Map that this enclave
+    /// will create. Total memory usage should be about 256 * this value, +
+    /// some overhead, and about 70% of the capacity won't be usable due to
+    /// hash table overflow. So the *number of tx outs* the enclave can support
+    /// is about 70% times this.
+    #[structopt(long, default_value = "1048576", env)]
+    pub omap_capacity: u64,
 }
 
 /// Converts a string containing number of seconds to a Duration object.

--- a/fog/view/server/tests/smoke_tests.rs
+++ b/fog/view/server/tests/smoke_tests.rs
@@ -69,6 +69,7 @@ fn get_test_environment(
             client_auth_token_secret: None,
             client_auth_token_max_lifetime: Default::default(),
             postgres_config: Default::default(),
+            omap_capacity: view_omap_capacity,
         };
 
         let enclave = SgxViewEnclave::new(


### PR DESCRIPTION
This is needed because the blockchain has gotten pretty big